### PR TITLE
Add settings screen for API key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This app uses the open-source MusicGen model hosted on Hugging Face to generate 
 
 ## Setup
 1. Obtain a free API token from [Hugging Face](https://huggingface.co/settings/tokens).
-2. Run the app once to create encrypted preferences, then open the device's `data/data/com.legendai.musichelper/shared_prefs/legend_prefs.xml` and insert your `API_KEY` value.
+2. Launch the app and open **Settings** from the menu to enter your API token. It will be stored securely in encrypted preferences.
 3. Alternatively, modify `Config.kt` to provide the token directly.
 4. Ensure the Android SDK path is configured. Copy `local.properties.example` to `local.properties` and update `sdk.dir` to point to your SDK installation.
 

--- a/app/src/main/java/com/legendai/musichelper/Config.kt
+++ b/app/src/main/java/com/legendai/musichelper/Config.kt
@@ -21,4 +21,18 @@ object Config {
         )
         return prefs.getString("API_KEY", "") ?: ""
     }
+
+    fun setApiKey(context: Context, apiKey: String) {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        val prefs = EncryptedSharedPreferences.create(
+            context,
+            "legend_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+        prefs.edit().putString("API_KEY", apiKey).apply()
+    }
 }

--- a/app/src/main/java/com/legendai/musichelper/MainActivity.kt
+++ b/app/src/main/java/com/legendai/musichelper/MainActivity.kt
@@ -8,9 +8,11 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.legendai.musichelper.ui.MusicScreen
+import com.legendai.musichelper.ui.SettingsScreen
 import com.legendai.musichelper.ui.theme.MusicGenTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,13 +20,18 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val viewModel: MusicViewModel = viewModel(factory = MusicViewModelFactory)
+            var showSettings by remember { mutableStateOf(false) }
             MusicGenTheme {
                 val snackbarHostState = remember { SnackbarHostState() }
                 val error by viewModel.error.collectAsStateWithLifecycle()
                 LaunchedEffect(error) {
                     error?.let { snackbarHostState.showSnackbar(it) }
                 }
-                MusicScreen(viewModel, snackbarHostState)
+                if (showSettings) {
+                    SettingsScreen { showSettings = false }
+                } else {
+                    MusicScreen(viewModel, snackbarHostState) { showSettings = true }
+                }
             }
         }
     }

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -3,6 +3,7 @@ package com.legendai.musichelper.ui
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.exoplayer2.ExoPlayer
@@ -17,10 +18,15 @@ import androidx.compose.ui.unit.dp
 import com.legendai.musichelper.GenerateSongRequest
 import com.legendai.musichelper.Parameters
 import com.legendai.musichelper.MusicViewModel
+import com.legendai.musichelper.GenerateSongResponse
 // Exporting to the app specific external directory does not require
 // runtime storage permission, so no permission APIs are needed here.
 @Composable
-fun MusicScreen(viewModel: MusicViewModel, snackbarHostState: SnackbarHostState) {
+fun MusicScreen(
+    viewModel: MusicViewModel,
+    snackbarHostState: SnackbarHostState,
+    onOpenSettings: () -> Unit = {}
+) {
     val progress by viewModel.progress.collectAsState()
     val audio by viewModel.audio.collectAsState()
     val chords by viewModel.chords.collectAsState()
@@ -31,6 +37,16 @@ fun MusicScreen(viewModel: MusicViewModel, snackbarHostState: SnackbarHostState)
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("MusicGen Helper") },
+                actions = {
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = null)
+                    }
+                }
+            )
+        },
         containerColor = MaterialTheme.colorScheme.background
     ) { padding ->
         Column(

--- a/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
@@ -1,0 +1,51 @@
+package com.legendai.musichelper.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.legendai.musichelper.Config
+
+@Composable
+fun SettingsScreen(onDone: () -> Unit) {
+    val context = LocalContext.current
+    var apiKey by remember { mutableStateOf(Config.getApiKey(context)) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onDone) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            TextField(
+                value = apiKey,
+                onValueChange = { apiKey = it },
+                label = { Text("Hugging Face API Key") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
+            Button(onClick = {
+                Config.setApiKey(context, apiKey)
+                onDone()
+            }) {
+                Text("Save")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- persist API key via `Config.setApiKey`
- add a composable `SettingsScreen` for entering the API key
- open the settings screen from a new action in the top app bar
- document how to use the settings screen in the README

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_684211b5d2208331a99360893de02b25