### PR TITLE
Add offline handling

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MainActivity.kt
+++ b/app/src/main/java/com/legendai/musichelper/MainActivity.kt
@@ -5,10 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.legendai.musichelper.ui.MusicScreen
 import com.legendai.musichelper.ui.theme.MusicGenTheme
@@ -20,10 +17,6 @@ class MainActivity : ComponentActivity() {
             val viewModel: MusicViewModel = viewModel(factory = MusicViewModelFactory)
             MusicGenTheme {
                 val snackbarHostState = remember { SnackbarHostState() }
-                val error by viewModel.error.collectAsStateWithLifecycle()
-                LaunchedEffect(error) {
-                    error?.let { snackbarHostState.showSnackbar(it) }
-                }
                 MusicScreen(viewModel, snackbarHostState)
             }
         }

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import com.legendai.musichelper.util.ChordGenerator
+import com.legendai.musichelper.util.NetworkUtils
 
 // ViewModel handling business logic and exposing Compose states
 class MusicViewModel(
@@ -29,6 +30,11 @@ class MusicViewModel(
 
     fun generateSong(context: Context, request: GenerateSongRequest, key: String, genre: String) {
         viewModelScope.launch(Dispatchers.IO) {
+            if (!NetworkUtils.isOnline(context)) {
+                _error.value = "No internet connection"
+                return@launch
+            }
+
             val apiKey = Config.getApiKey(context)
             try {
                 _progress.value = 0.1f

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -24,10 +24,15 @@ fun MusicScreen(viewModel: MusicViewModel, snackbarHostState: SnackbarHostState)
     val progress by viewModel.progress.collectAsState()
     val audio by viewModel.audio.collectAsState()
     val chords by viewModel.chords.collectAsState()
+    val error by viewModel.error.collectAsState()
     var genre by remember { mutableStateOf("rock") }
     var key by remember { mutableStateOf(TextFieldValue("C")) }
     var tempo by remember { mutableStateOf(120f) }
     var duration by remember { mutableStateOf(30f) }
+
+    LaunchedEffect(error) {
+        error?.let { snackbarHostState.showSnackbar(it) }
+    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/app/src/main/java/com/legendai/musichelper/util/NetworkUtils.kt
+++ b/app/src/main/java/com/legendai/musichelper/util/NetworkUtils.kt
@@ -1,0 +1,15 @@
+package com.legendai.musichelper.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+// Utility functions related to network connectivity
+object NetworkUtils {
+    fun isOnline(context: Context): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = cm.activeNetwork ?: return false
+        val capabilities = cm.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}


### PR DESCRIPTION
## Summary
- add NetworkUtils helper to check for connectivity
- check network status in `generateSong`
- show snackbar in `MusicScreen` for errors
- simplify MainActivity by moving snackbar logic into UI

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684211bae4bc83319be8eb4c413a23c9