### PR TITLE
Add progress reporting for song generation

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicRepository.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicRepository.kt
@@ -9,6 +9,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import com.legendai.musichelper.network.ProgressResponseBody
 
 // Repository executing network calls with OkHttp
 class MusicRepository(private val client: OkHttpClient) {
@@ -16,7 +17,8 @@ class MusicRepository(private val client: OkHttpClient) {
     suspend fun generateSong(
         apiKey: String,
         request: GenerateSongRequest,
-        context: Context
+        context: Context,
+        onProgress: (Float) -> Unit = {}
     ): GenerateSongResponse {
         val json = Json.encodeToString(request)
         val body = json.toRequestBody("application/json".toMediaType())
@@ -27,8 +29,12 @@ class MusicRepository(private val client: OkHttpClient) {
             .build()
         client.newCall(httpRequest).execute().use { response ->
             if (!response.isSuccessful) throw java.io.IOException("Network error")
+
+            val body = response.body ?: throw java.io.IOException("Empty body")
+            val progressBody = ProgressResponseBody(body, onProgress)
+
             val file = File.createTempFile("musicgen_", ".wav", context.cacheDir)
-            response.body?.byteStream()?.use { input ->
+            progressBody.byteStream().use { input ->
                 file.outputStream().use { output ->
                     input.copyTo(output)
                 }

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -31,8 +31,10 @@ class MusicViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             val apiKey = Config.getApiKey(context)
             try {
-                _progress.value = 0.1f
-                val response = repository.generateSong(apiKey, request, context)
+                _progress.value = 0f
+                val response = repository.generateSong(apiKey, request, context) { p ->
+                    _progress.value = p
+                }
                 _audio.value = response
                 _chords.value = ChordGenerator.suggest(key, genre)
                 _progress.value = 1f

--- a/app/src/main/java/com/legendai/musichelper/network/ProgressResponseBody.kt
+++ b/app/src/main/java/com/legendai/musichelper/network/ProgressResponseBody.kt
@@ -1,0 +1,46 @@
+package com.legendai.musichelper.network
+
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import okio.*
+
+/**
+ * ResponseBody wrapper that reports download progress.
+ */
+class ProgressResponseBody(
+    private val responseBody: ResponseBody,
+    private val onProgress: (Float) -> Unit
+) : ResponseBody() {
+
+    private var bufferedSource: BufferedSource? = null
+    private var totalBytesRead = 0L
+
+    override fun contentLength(): Long = responseBody.contentLength()
+
+    override fun contentType(): MediaType? = responseBody.contentType()
+
+    override fun source(): BufferedSource {
+        if (bufferedSource == null) {
+            bufferedSource = source(responseBody.source()).buffer()
+        }
+        return bufferedSource!!
+    }
+
+    private fun source(source: Source): Source {
+        val total = contentLength()
+        return object : ForwardingSource(source) {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                val bytesRead = super.read(sink, byteCount)
+                if (bytesRead != -1L) {
+                    totalBytesRead += bytesRead
+                    if (total > 0) {
+                        onProgress(totalBytesRead.toFloat() / total)
+                    }
+                } else {
+                    onProgress(1f)
+                }
+                return bytesRead
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -98,6 +98,7 @@ fun MusicScreen(viewModel: MusicViewModel, snackbarHostState: SnackbarHostState)
 
             if (progress > 0f && progress < 1f) {
                 LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+                Text(text = "${(progress * 100).toInt()}%", modifier = Modifier.align(Alignment.CenterHorizontally))
             }
 
             audio?.let { result ->

--- a/app/src/test/java/com/legendai/musichelper/MusicRepositoryTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicRepositoryTest.kt
@@ -55,10 +55,12 @@ class MusicRepositoryTest {
                 .setHeader("Content-Type", "application/octet-stream")
         )
 
+        var progress = 0f
         val result = repository.generateSong(
             apiKey = "token",
             request = GenerateSongRequest(inputs = "prompt"),
-            context = context
+            context = context,
+            onProgress = { progress = it }
         )
 
         val recorded = server.takeRequest()
@@ -67,6 +69,7 @@ class MusicRepositoryTest {
         val file = File(result.audioPath)
         assertTrue(file.exists())
         assertEquals("OK", file.readText())
+        assertEquals(1f, progress)
     }
 
     @Test
@@ -77,7 +80,8 @@ class MusicRepositoryTest {
             repository.generateSong(
                 apiKey = "token",
                 request = GenerateSongRequest(inputs = "prompt"),
-                context = context
+                context = context,
+                onProgress = {}
             )
         }
     }


### PR DESCRIPTION
## Summary
- show download progress via `ProgressResponseBody`
- surface progress updates through `MusicRepository.generateSong`
- update `MusicViewModel` and `MusicScreen` to display incremental progress
- test progress callback in `MusicRepositoryTest`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684211bc2b448331ab7225857a9a75b4