### PR TITLE
Add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ This app uses the open-source MusicGen model hosted on Hugging Face to generate 
 6. Connect an Android device or start an emulator.
 7. Press **Run** or execute `./gradlew assembleDebug` from the command line.
 
+## Testing
+1. If `gradle/wrapper/gradle-wrapper.jar` is missing, bootstrap the wrapper:
+   ```bash
+   gradle wrapper
+   ```
+   This downloads the wrapper JAR so the following commands can run.
+2. Execute the unit tests:
+   ```bash
+   ./gradlew test
+   ```
+
 ## Usage
 1. Pick a genre or select a short reference clip.
 2. Adjust tempo, key, and duration sliders.


### PR DESCRIPTION
## Summary
- document running the unit tests using gradle

## Testing
- `gradle wrapper --no-daemon`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842882069b88331898238bbf3e469ae