### PR TITLE
Add Compose UI instrumentation tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,4 +42,9 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
     testImplementation "androidx.test:core:1.5.0"
     testImplementation "org.robolectric:robolectric:4.10.3"
+
+    androidTestImplementation "androidx.test.ext:junit:1.1.5"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.4.0"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:1.4.0"
 }

--- a/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
@@ -1,0 +1,47 @@
+package com.legendai.musichelper
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun openSettings_displaysSettingsScreen() {
+        composeTestRule.onNodeWithContentDescription("Settings").performClick()
+        composeTestRule.onNodeWithText("Hugging Face API Key").assertIsDisplayed()
+    }
+
+    @Test
+    fun generateSong_showsErrorSnackbar() {
+        composeTestRule.onNodeWithText("Generate Song").performClick()
+        composeTestRule.onNodeWithText("Network error—please retry").assertIsDisplayed()
+    }
+
+    @Test
+    fun export_showsSavedMessage() {
+        // Provide a fake audio response so Export button is visible
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            val viewModel = androidx.lifecycle.ViewModelProvider(activity)[MusicViewModel::class.java]
+            val cache = activity.cacheDir
+            val file = java.io.File(cache, "sample.wav").apply { writeText("data") }
+            viewModel.apply {
+                val field = this::class.java.getDeclaredField("_audio")
+                field.isAccessible = true
+                val state = field.get(this) as kotlinx.coroutines.flow.MutableStateFlow<GenerateSongResponse?>
+                state.value = GenerateSongResponse(file.absolutePath)
+            }
+        }
+        composeTestRule.onNodeWithText("Export").performClick()
+        composeTestRule.onNodeWithText("Saved to").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -42,7 +42,10 @@ fun MusicScreen(
                 title = { Text("MusicGen Helper") },
                 actions = {
                     IconButton(onClick = onOpenSettings) {
-                        Icon(Icons.Default.Settings, contentDescription = null)
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = "Settings"
+                        )
                     }
                 }
             )


### PR DESCRIPTION
## Summary
- add instrumentation dependencies for Compose tests
- tag Settings icon for testing
- add `MainActivityTest` UI tests covering Settings, generation error, export

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842881fc9b88331bedb31548cc6e8c1