### PR TITLE
Handle missing API key

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -28,8 +28,12 @@ class MusicViewModel(
     val chords: StateFlow<List<String>> = _chords
 
     fun generateSong(context: Context, request: GenerateSongRequest, key: String, genre: String) {
+        val apiKey = Config.getApiKey(context)
+        if (apiKey.isBlank()) {
+            _error.value = "Please set your API key in Settings"
+            return
+        }
         viewModelScope.launch(Dispatchers.IO) {
-            val apiKey = Config.getApiKey(context)
             try {
                 _progress.value = 0f
                 val response = repository.generateSong(apiKey, request, context) { p ->

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
@@ -82,4 +82,17 @@ class MusicViewModelTest {
         assertNull(viewModel.audio.value)
         assertEquals("Network error—please retry", viewModel.error.value)
     }
+
+    @Test
+    fun generateSong_noApiKey_setsError() = runTest(mainDispatcherRule.dispatcher) {
+        Config.setApiKey(context, "")
+
+        viewModel.generateSong(context, GenerateSongRequest("prompt"), "C", "rock")
+        advanceUntilIdle()
+
+        assertEquals(0f, viewModel.progress.value)
+        assertNull(viewModel.audio.value)
+        assertTrue(viewModel.chords.value.isEmpty())
+        assertEquals("Please set your API key in Settings", viewModel.error.value)
+    }
 }


### PR DESCRIPTION
## Summary
- validate API key presence before generating song
- surface a clear error message when API key is missing
- test new error case in `MusicViewModel`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842881eee8483319bee388d30ecf4d4