### PR TITLE
Add export history screen

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/ExportStore.kt
+++ b/app/src/main/java/com/legendai/musichelper/ExportStore.kt
@@ -1,0 +1,37 @@
+package com.legendai.musichelper
+
+import android.content.Context
+
+/**
+ * Simple helper for tracking exported files using SharedPreferences.
+ */
+object ExportStore {
+    private const val PREFS = "exports"
+    private const val KEY_ENTRIES = "entries"
+
+    data class Entry(val fileName: String, val time: Long)
+
+    fun add(context: Context, fileName: String) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val set = prefs.getStringSet(KEY_ENTRIES, mutableSetOf())!!.toMutableSet()
+        val entry = "$fileName|${System.currentTimeMillis()}"
+        set.add(entry)
+        prefs.edit().putStringSet(KEY_ENTRIES, set).apply()
+    }
+
+    fun list(context: Context): List<Entry> {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val set = prefs.getStringSet(KEY_ENTRIES, emptySet()) ?: emptySet()
+        return set.mapNotNull {
+            val parts = it.split("|")
+            if (parts.size == 2) Entry(parts[0], parts[1].toLong()) else null
+        }.sortedByDescending { it.time }
+    }
+
+    fun remove(context: Context, fileName: String) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val set = prefs.getStringSet(KEY_ENTRIES, mutableSetOf())!!.toMutableSet()
+        set.removeIf { it.startsWith("$fileName|") }
+        prefs.edit().putStringSet(KEY_ENTRIES, set).apply()
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/MainActivity.kt
+++ b/app/src/main/java/com/legendai/musichelper/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.legendai.musichelper.ui.MusicScreen
 import com.legendai.musichelper.ui.SettingsScreen
+import com.legendai.musichelper.ui.ExportsScreen
 import com.legendai.musichelper.ui.theme.MusicGenTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,16 +22,22 @@ class MainActivity : ComponentActivity() {
         setContent {
             val viewModel: MusicViewModel = viewModel(factory = MusicViewModelFactory)
             var showSettings by remember { mutableStateOf(false) }
+            var showExports by remember { mutableStateOf(false) }
             MusicGenTheme {
                 val snackbarHostState = remember { SnackbarHostState() }
                 val error by viewModel.error.collectAsStateWithLifecycle()
                 LaunchedEffect(error) {
                     error?.let { snackbarHostState.showSnackbar(it) }
                 }
-                if (showSettings) {
-                    SettingsScreen { showSettings = false }
-                } else {
-                    MusicScreen(viewModel, snackbarHostState) { showSettings = true }
+                when {
+                    showSettings -> SettingsScreen { showSettings = false }
+                    showExports -> ExportsScreen { showExports = false }
+                    else -> MusicScreen(
+                        viewModel,
+                        snackbarHostState,
+                        onOpenSettings = { showSettings = true },
+                        onOpenExports = { showExports = true }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -50,8 +50,12 @@ class MusicViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val input = File(response.audioPath)
-                val output = File(context.getExternalFilesDir(null), "musicgen.wav")
+                val exportsDir = context.getExternalFilesDir("exports")
+                exportsDir?.mkdirs()
+                val fileName = "musicgen_${System.currentTimeMillis()}.wav"
+                val output = File(exportsDir, fileName)
                 input.copyTo(output, overwrite = true)
+                ExportStore.add(context, fileName)
                 _error.value = "Saved to ${output.absolutePath}"
             } catch (e: Exception) {
                 _error.value = "Network error—please retry"

--- a/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
@@ -1,0 +1,63 @@
+package com.legendai.musichelper.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.legendai.musichelper.ExportStore
+import com.legendai.musichelper.ui.AudioPlayer
+import java.io.File
+import java.text.DateFormat
+
+@Composable
+fun ExportsScreen(onDone: () -> Unit) {
+    val context = LocalContext.current
+    var exports by remember { mutableStateOf(ExportStore.list(context)) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Exports") },
+                navigationIcon = {
+                    IconButton(onClick = onDone) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            items(exports) { entry ->
+                val file = File(context.getExternalFilesDir("exports"), entry.fileName)
+                Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                    val date = remember(entry.time) {
+                        DateFormat.getDateTimeInstance().format(entry.time)
+                    }
+                    Text(entry.fileName)
+                    Text(date, style = MaterialTheme.typography.bodySmall)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        AudioPlayer(file.absolutePath, label = "")
+                        IconButton(onClick = {
+                            file.delete()
+                            ExportStore.remove(context, entry.fileName)
+                            exports = ExportStore.list(context)
+                        }) {
+                            Icon(Icons.Default.Delete, contentDescription = null)
+                        }
+                    }
+                }
+                Divider()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.List
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.exoplayer2.ExoPlayer
@@ -25,7 +26,8 @@ import com.legendai.musichelper.GenerateSongResponse
 fun MusicScreen(
     viewModel: MusicViewModel,
     snackbarHostState: SnackbarHostState,
-    onOpenSettings: () -> Unit = {}
+    onOpenSettings: () -> Unit = {},
+    onOpenExports: () -> Unit = {}
 ) {
     val progress by viewModel.progress.collectAsState()
     val audio by viewModel.audio.collectAsState()
@@ -41,6 +43,9 @@ fun MusicScreen(
             TopAppBar(
                 title = { Text("MusicGen Helper") },
                 actions = {
+                    IconButton(onClick = onOpenExports) {
+                        Icon(Icons.Default.List, contentDescription = null)
+                    }
                     IconButton(onClick = onOpenSettings) {
                         Icon(Icons.Default.Settings, contentDescription = null)
                     }


### PR DESCRIPTION
## Summary
- save exports to an "exports" folder and track them via `ExportStore`
- allow viewing previous exports and deleting them
- add export history button

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842881cacfc8331a7364235f764c49c