### PR TITLE
Handle missing external storage for exports

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -58,9 +58,14 @@ class MusicViewModel(
     fun mixdownAndExport(context: Context, response: GenerateSongResponse) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val input = File(response.audioPath)
                 val exportsDir = context.getExternalFilesDir("exports")
-                exportsDir?.mkdirs()
+                if (exportsDir == null) {
+                    _error.value = "Storage unavailable"
+                    return@launch
+                }
+                exportsDir.mkdirs()
+
+                val input = File(response.audioPath)
                 val fileName = "musicgen_${System.currentTimeMillis()}.wav"
                 val output = File(exportsDir, fileName)
                 input.copyTo(output, overwrite = true)
@@ -75,7 +80,13 @@ class MusicViewModel(
     fun mixAndExport(context: Context, responses: List<GenerateSongResponse>) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val output = File(context.getExternalFilesDir(null), "musicgen_mix.wav")
+                val baseDir = context.getExternalFilesDir(null)
+                if (baseDir == null) {
+                    _error.value = "Storage unavailable"
+                    return@launch
+                }
+
+                val output = File(baseDir, "musicgen_mix.wav")
                 val urls = responses.map { File(it.audioPath).toURI().toString() }
                 AudioMixer.mixWavFiles(urls, output)
                 _error.value = "Saved to ${output.absolutePath}"

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
@@ -2,6 +2,7 @@ package com.legendai.musichelper
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -94,5 +95,31 @@ class MusicViewModelTest {
         assertNull(viewModel.audio.value)
         assertTrue(viewModel.chords.value.isEmpty())
         assertEquals("Please set your API key in Settings", viewModel.error.value)
+    }
+
+    @Test
+    fun mixdownAndExport_nullDir_setsError() = runTest(mainDispatcherRule.dispatcher) {
+        val audio = File.createTempFile("clip_", ".wav")
+        val wrapper = object : android.content.ContextWrapper(context) {
+            override fun getExternalFilesDir(type: String?): File? = null
+        }
+
+        viewModel.mixdownAndExport(wrapper, GenerateSongResponse(audio.absolutePath))
+        advanceUntilIdle()
+
+        assertEquals("Storage unavailable", viewModel.error.value)
+    }
+
+    @Test
+    fun mixAndExport_nullDir_setsError() = runTest(mainDispatcherRule.dispatcher) {
+        val audio = File.createTempFile("clip_", ".wav")
+        val wrapper = object : android.content.ContextWrapper(context) {
+            override fun getExternalFilesDir(type: String?): File? = null
+        }
+
+        viewModel.mixAndExport(wrapper, listOf(GenerateSongResponse(audio.absolutePath)))
+        advanceUntilIdle()
+
+        assertEquals("Storage unavailable", viewModel.error.value)
     }
 }


### PR DESCRIPTION
## Summary
- check `getExternalFilesDir` in `MusicViewModel` before exporting
- inform user when storage is unavailable
- test new error paths in `MusicViewModel`

## Testing
- `gradle wrapper`
- `./gradlew test` *(fails: Could not determine dependencies / Unsupported class file major version)*

------
https://chatgpt.com/codex/tasks/task_e_68428f6bad4083318221d26388292ce2