### PR TITLE
Stream WAV mixing

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/util/AudioMixer.kt
+++ b/app/src/main/java/com/legendai/musichelper/util/AudioMixer.kt
@@ -1,6 +1,8 @@
 package com.legendai.musichelper.util
 
 import java.io.File
+import java.io.InputStream
+import java.io.RandomAccessFile
 import java.net.URL
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -18,47 +20,95 @@ object AudioMixer {
     fun mixWavFiles(urls: List<String>, output: File) {
         require(urls.isNotEmpty()) { "No input files provided" }
 
-        // Read header and PCM data from each input
+        data class Input(val header: ByteArray, val stream: InputStream, var remaining: Int)
+
+        // Prepare input streams and read their headers
         val inputs = urls.map { urlStr ->
-            val bytes = URL(urlStr).readBytes()
-            val header = bytes.copyOfRange(0, 44)
-            val pcm = bytes.copyOfRange(44, bytes.size)
-            val shortCount = pcm.size / 2
-            val samples = ShortArray(shortCount)
-            val bb = ByteBuffer.wrap(pcm).order(ByteOrder.LITTLE_ENDIAN)
-            for (i in 0 until shortCount) {
-                samples[i] = bb.short
-            }
-            header to samples
+            val stream = URL(urlStr).openStream().buffered()
+            val header = ByteArray(44)
+            val read = stream.read(header)
+            require(read == 44) { "Invalid WAV header for $urlStr" }
+            val dataSize = ByteBuffer.wrap(header, 40, 4)
+                .order(ByteOrder.LITTLE_ENDIAN).int
+            Input(header, stream, dataSize)
         }
 
-        val baseHeader = inputs.first().first.copyOf()
-        val maxSamples = inputs.maxOf { it.second.size }
-        val mixed = ShortArray(maxSamples)
+        val baseHeader = inputs.first().header.clone()
 
-        for (i in 0 until maxSamples) {
-            var sum = 0
-            var count = 0
-            for ((_, data) in inputs) {
-                if (i < data.size) {
-                    sum += data[i].toInt()
-                    count++
+        val bufferSamples = 4096
+        val inBuffers = Array(inputs.size) { ByteArray(bufferSamples * 2) }
+        val shortBuffers = Array(inputs.size) { ShortArray(bufferSamples) }
+        val shortCounts = IntArray(inputs.size)
+        val outShorts = ShortArray(bufferSamples)
+        val outBytes = ByteArray(bufferSamples * 2)
+
+        var totalSamples = 0
+
+        output.outputStream().use { out ->
+            out.write(baseHeader) // placeholder
+
+            while (inputs.any { it.remaining > 0 }) {
+                var maxSamplesRead = 0
+                for (i in inputs.indices) {
+                    val input = inputs[i]
+                    if (input.remaining > 0) {
+                        val toRead = minOf(bufferSamples * 2, input.remaining)
+                        val readBytes = input.stream.read(inBuffers[i], 0, toRead)
+                        if (readBytes > 0) {
+                            input.remaining -= readBytes
+                            val bb = ByteBuffer.wrap(inBuffers[i], 0, readBytes)
+                                .order(ByteOrder.LITTLE_ENDIAN)
+                            val sc = readBytes / 2
+                            shortCounts[i] = sc
+                            for (s in 0 until sc) {
+                                shortBuffers[i][s] = bb.short
+                            }
+                            if (sc < bufferSamples) {
+                                java.util.Arrays.fill(shortBuffers[i], sc, bufferSamples, 0)
+                            }
+                            maxSamplesRead = maxOf(maxSamplesRead, sc)
+                        } else {
+                            shortCounts[i] = 0
+                        }
+                    } else {
+                        shortCounts[i] = 0
+                    }
                 }
+
+                if (maxSamplesRead == 0) {
+                    break
+                }
+
+                for (s in 0 until maxSamplesRead) {
+                    var sum = 0
+                    var count = 0
+                    for (i in inputs.indices) {
+                        if (s < shortCounts[i]) {
+                            sum += shortBuffers[i][s].toInt()
+                            count++
+                        }
+                    }
+                    outShorts[s] = if (count == 0) 0 else (sum / count).toShort()
+                }
+
+                val bbOut = ByteBuffer.wrap(outBytes).order(ByteOrder.LITTLE_ENDIAN)
+                for (i in 0 until maxSamplesRead) {
+                    bbOut.putShort(outShorts[i])
+                }
+                out.write(outBytes, 0, maxSamplesRead * 2)
+                totalSamples += maxSamplesRead
             }
-            mixed[i] = if (count == 0) 0 else (sum / count).toShort()
         }
 
-        // Update header sizes
-        val dataSize = mixed.size * 2
+        val dataSize = totalSamples * 2
         ByteBuffer.wrap(baseHeader, 40, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(dataSize)
         ByteBuffer.wrap(baseHeader, 4, 4).order(ByteOrder.LITTLE_ENDIAN).putInt(36 + dataSize)
 
-        // Write header and mixed samples
-        output.outputStream().use { out ->
-            out.write(baseHeader)
-            val buffer = ByteBuffer.allocate(dataSize).order(ByteOrder.LITTLE_ENDIAN)
-            for (s in mixed) buffer.putShort(s)
-            out.write(buffer.array())
+        RandomAccessFile(output, "rw").use { raf ->
+            raf.seek(0)
+            raf.write(baseHeader)
         }
+
+        inputs.forEach { it.stream.close() }
     }
 }

--- a/app/src/test/java/com/legendai/musichelper/util/AudioMixerTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/util/AudioMixerTest.kt
@@ -47,11 +47,18 @@ class AudioMixerTest {
         val f2 = createWav(s2)
         val out = File.createTempFile("mix_out_", ".wav")
         AudioMixer.mixWavFiles(listOf(f1.toURI().toString(), f2.toURI().toString()), out)
-        val bytes = out.readBytes()
-        val subSize = ByteBuffer.wrap(bytes, 40, 4).order(ByteOrder.LITTLE_ENDIAN).int
-        assertEquals(s1.size * 2, subSize)
-        val firstSample = ByteBuffer.wrap(bytes, 44, 2).order(ByteOrder.LITTLE_ENDIAN).short
-        assertEquals(0, firstSample)
+        val header = ByteArray(44)
+        out.inputStream().use { input ->
+            input.read(header)
+            val subSize = ByteBuffer.wrap(header, 40, 4)
+                .order(ByteOrder.LITTLE_ENDIAN).int
+            assertEquals(s1.size * 2, subSize)
+            val firstBytes = ByteArray(2)
+            input.read(firstBytes)
+            val firstSample = ByteBuffer.wrap(firstBytes)
+                .order(ByteOrder.LITTLE_ENDIAN).short
+            assertEquals(0, firstSample)
+        }
     }
 
     @Test
@@ -68,17 +75,29 @@ class AudioMixerTest {
             out
         )
 
-        val bytes = out.readBytes()
-        val dataSize = ByteBuffer.wrap(bytes, 40, 4)
-            .order(ByteOrder.LITTLE_ENDIAN).int
-        assertEquals(longSamples.size * 2, dataSize)
+        val header = ByteArray(44)
+        val mixed: ShortArray
+        out.inputStream().use { input ->
+            input.read(header)
+            val dataSize = ByteBuffer.wrap(header, 40, 4)
+                .order(ByteOrder.LITTLE_ENDIAN).int
+            assertEquals(longSamples.size * 2, dataSize)
 
-        val sampleCount = dataSize / 2
-        val mixed = ShortArray(sampleCount)
-        val bb = ByteBuffer.wrap(bytes, 44, dataSize)
-            .order(ByteOrder.LITTLE_ENDIAN)
-        for (i in 0 until sampleCount) {
-            mixed[i] = bb.short
+            val sampleCount = dataSize / 2
+            mixed = ShortArray(sampleCount)
+            val buffer = ByteArray(256)
+            var index = 0
+            while (index < sampleCount) {
+                val toRead = minOf(buffer.size, (sampleCount - index) * 2)
+                val r = input.read(buffer, 0, toRead)
+                if (r <= 0) break
+                val bb = ByteBuffer.wrap(buffer, 0, r)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                val sc = r / 2
+                for (i in 0 until sc) {
+                    mixed[index++] = bb.short
+                }
+            }
         }
 
         // Beyond the end of the short file only the long file contributes


### PR DESCRIPTION
## Summary
- stream audio data instead of reading full files in `AudioMixer`
- test streaming behaviour in `AudioMixerTest`

## Testing
- `gradle wrapper`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429e6559e88331a0add3bd49f45a99