### PR TITLE
Enable live chord suggestions

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -31,6 +31,10 @@ class MusicViewModel(
     private val _chords = MutableStateFlow<List<String>>(emptyList())
     val chords: StateFlow<List<String>> = _chords
 
+    fun updateChords(key: String, genre: String) {
+        _chords.value = ChordGenerator.suggest(key, genre)
+    }
+
     fun generateSong(context: Context, request: GenerateSongRequest, key: String, genre: String) {
         val apiKey = Config.getApiKey(context)
         if (apiKey.isBlank()) {
@@ -45,7 +49,7 @@ class MusicViewModel(
                 }
                 _audio.value = response
                 _clips.value = _clips.value + response
-                _chords.value = ChordGenerator.suggest(key, genre)
+                updateChords(key, genre)
                 _progress.value = 1f
             } catch (e: Exception) {
                 _error.value = "Network error—please retry"

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -41,6 +41,10 @@ fun MusicScreen(
     var duration by remember { mutableStateOf(30f) }
     var selectedClips by remember { mutableStateOf(setOf<String>()) }
 
+    LaunchedEffect(key.text, genre) {
+        viewModel.updateChords(key.text, genre)
+    }
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {


### PR DESCRIPTION
## Summary
- move chord generation into new `updateChords` method
- refresh chords automatically when key or genre change

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429e6698008331a284b143a0d143db