### PR TITLE
Allow cancelling generation

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicRepository.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicRepository.kt
@@ -12,7 +12,16 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import com.legendai.musichelper.network.ProgressResponseBody
 
 // Repository executing network calls with OkHttp
+import okhttp3.Call
+
 class MusicRepository(private val client: OkHttpClient) {
+
+    private var activeCall: Call? = null
+
+    fun cancel() {
+        activeCall?.cancel()
+        activeCall = null
+    }
 
     suspend fun generateSong(
         apiKey: String,
@@ -27,19 +36,25 @@ class MusicRepository(private val client: OkHttpClient) {
             .post(body)
             .addHeader("Authorization", "Bearer $apiKey")
             .build()
-        client.newCall(httpRequest).execute().use { response ->
-            if (!response.isSuccessful) throw java.io.IOException("Network error")
+        val call = client.newCall(httpRequest)
+        activeCall = call
+        try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) throw java.io.IOException("Network error")
 
-            val body = response.body ?: throw java.io.IOException("Empty body")
-            val progressBody = ProgressResponseBody(body, onProgress)
+                val body = response.body ?: throw java.io.IOException("Empty body")
+                val progressBody = ProgressResponseBody(body, onProgress)
 
-            val file = File.createTempFile("musicgen_", ".wav", context.cacheDir)
-            progressBody.byteStream().use { input ->
-                file.outputStream().use { output ->
-                    input.copyTo(output)
+                val file = File.createTempFile("musicgen_", ".wav", context.cacheDir)
+                progressBody.byteStream().use { input ->
+                    file.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
                 }
+                return GenerateSongResponse(file.absolutePath)
             }
-            return GenerateSongResponse(file.absolutePath)
+        } finally {
+            activeCall = null
         }
     }
 }

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -54,6 +54,11 @@ class MusicViewModel(
         }
     }
 
+    fun cancelGeneration() {
+        repository.cancel()
+        _progress.value = 0f
+    }
+
     fun clearError() { _error.value = null }
     fun mixdownAndExport(context: Context, response: GenerateSongResponse) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -125,8 +125,19 @@ fun MusicScreen(
             }) { Text("Generate Song") }
 
             if (progress > 0f && progress < 1f) {
-                LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
-                Text(text = "${(progress * 100).toInt()}%", modifier = Modifier.align(Alignment.CenterHorizontally))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    LinearProgressIndicator(
+                        progress = progress,
+                        modifier = Modifier
+                            .weight(1f)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = { viewModel.cancelGeneration() }) { Text("Cancel") }
+                }
+                Text(
+                    text = "${(progress * 100).toInt()}%",
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                )
             }
 
             LazyColumn {


### PR DESCRIPTION
## Summary
- keep reference to the active `Call` inside `MusicRepository`
- add `cancelGeneration` in `MusicViewModel`
- include cancel button on `MusicScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68429e68bb208331abcd19ac0398bc8c