### PR TITLE
Fix export error messages

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -72,7 +72,7 @@ class MusicViewModel(
                 ExportStore.add(context, fileName)
                 _error.value = "Saved to ${output.absolutePath}"
             } catch (e: Exception) {
-                _error.value = "Network error—please retry"
+                _error.value = "File error—please retry"
             }
         }
     }
@@ -91,7 +91,7 @@ class MusicViewModel(
                 AudioMixer.mixWavFiles(urls, output)
                 _error.value = "Saved to ${output.absolutePath}"
             } catch (e: Exception) {
-                _error.value = "Network error—please retry"
+                _error.value = "File error—please retry"
             }
         }
     }


### PR DESCRIPTION
## Summary
- clarify failure messaging in `mixdownAndExport` and `mixAndExport`

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68429e979be0833187595fda7bd80c11