### PR TITLE
Fix ExportStore list splitting

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/ExportStore.kt
+++ b/app/src/main/java/com/legendai/musichelper/ExportStore.kt
@@ -23,7 +23,7 @@ object ExportStore {
         val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
         val set = prefs.getStringSet(KEY_ENTRIES, emptySet()) ?: emptySet()
         return set.mapNotNull {
-            val parts = it.split("|")
+            val parts = it.split('|', limit = 2)
             if (parts.size == 2) Entry(parts[0], parts[1].toLong()) else null
         }.sortedByDescending { it.time }
     }

--- a/app/src/test/java/com/legendai/musichelper/ExportStoreTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/ExportStoreTest.kt
@@ -48,6 +48,18 @@ class ExportStoreTest {
     }
 
     @Test
+    fun listParsesPipeSeparatedEntries() {
+        val prefs = context.getSharedPreferences("exports", Context.MODE_PRIVATE)
+        prefs.edit().putStringSet("entries", setOf("file|name.wav|123"))!!.apply()
+
+        val list = ExportStore.list(context)
+
+        assertEquals(1, list.size)
+        assertEquals("file|name.wav", list[0].fileName)
+        assertEquals(123, list[0].time)
+    }
+
+    @Test
     fun removeDeletesEntry() {
         ExportStore.add(context, "a.wav")
         ExportStore.add(context, "b.wav")


### PR DESCRIPTION
## Summary
- fix ExportStore.list parsing using `split('|', limit = 2)`
- add unit test that verifies pipe-delimited entries are read correctly

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a316b22c833197813fdd234c7bb8