### PR TITLE
Add buildConfig and env fallbacks for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This app uses the open-source MusicGen model hosted on Hugging Face to generate 
 ## Setup
 1. Obtain a free API token from [Hugging Face](https://huggingface.co/settings/tokens).
 2. Launch the app and open **Settings** from the menu to enter your API token. It will be stored securely in encrypted preferences.
-3. Alternatively, modify `Config.kt` to provide the token directly.
+3. You can also provide the key via the `musicgenApiKey` Gradle property or the
+   `MUSICGEN_API_KEY` environment variable, or modify `Config.kt` to hard-code it
+   directly.
 4. Ensure the Android SDK path is configured. Copy `local.properties.example` to `local.properties` and update `sdk.dir` to point to your SDK installation.
 
 ## Build & Run

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,10 +15,14 @@ android {
         targetSdk 34
         versionCode 1
         versionName "1.0"
+
+        def apiKey = project.hasProperty('musicgenApiKey') ? project.property('musicgenApiKey') : ""
+        buildConfigField "String", "MUSICGEN_API_KEY", '"' + apiKey + '"'
     }
 
     buildFeatures {
         compose true
+        buildConfig true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.4.0'

--- a/app/src/main/java/com/legendai/musichelper/Config.kt
+++ b/app/src/main/java/com/legendai/musichelper/Config.kt
@@ -3,12 +3,20 @@ package com.legendai.musichelper
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.legendai.musichelper.BuildConfig
 
 // Configuration values such as API base URL and API key loader
 object Config {
     const val API_BASE_URL = "https://api-inference.huggingface.co/"
 
     fun getApiKey(context: Context): String {
+        if (BuildConfig.MUSICGEN_API_KEY.isNotBlank()) {
+            return BuildConfig.MUSICGEN_API_KEY
+        }
+        System.getenv("MUSICGEN_API_KEY")?.takeIf { it.isNotBlank() }?.let {
+            return it
+        }
+
         val masterKey = MasterKey.Builder(context)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()


### PR DESCRIPTION
## Summary
- allow retrieving the API key from `BuildConfig.MUSICGEN_API_KEY` or the `MUSICGEN_API_KEY` environment variable
- generate BuildConfig constant from a `musicgenApiKey` Gradle property
- document the new API key options

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a31deb9c8331aee8aee04eee03d1