### PR TITLE
Persist user preferences with DataStore

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
     implementation "androidx.compose.material3:material3:1.1.0"
     implementation "androidx.compose.material:material-icons-extended:1.4.0"
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"

--- a/app/src/main/java/com/legendai/musichelper/MusicGenApplication.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicGenApplication.kt
@@ -1,4 +1,15 @@
 package com.legendai.musichelper
 
 import android.app.Application
-class MusicGenApplication : Application()
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.userPreferencesDataStore by preferencesDataStore("user_prefs")
+
+class MusicGenApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        ServiceLocator.init(this)
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import com.legendai.musichelper.util.ChordGenerator
 import com.legendai.musichelper.util.AudioMixer
+import com.legendai.musichelper.UserPreferencesRepository
 
 // ViewModel handling business logic and exposing Compose states
 class MusicViewModel(
-    private val repository: MusicRepository
+    private val repository: MusicRepository,
+    private val prefs: UserPreferencesRepository,
 ) : ViewModel() {
 
     private val _progress = MutableStateFlow(0f)
@@ -24,6 +26,48 @@ class MusicViewModel(
 
     private val _clips = MutableStateFlow<List<GenerateSongResponse>>(emptyList())
     val clips: StateFlow<List<GenerateSongResponse>> = _clips
+
+    private val _genre = MutableStateFlow("rock")
+    val genre: StateFlow<String> = _genre
+
+    private val _keyPref = MutableStateFlow("C")
+    val key: StateFlow<String> = _keyPref
+
+    private val _tempo = MutableStateFlow(120f)
+    val tempo: StateFlow<Float> = _tempo
+
+    private val _duration = MutableStateFlow(30)
+    val duration: StateFlow<Int> = _duration
+
+    init {
+        viewModelScope.launch {
+            val stored = prefs.getPreferences()
+            _genre.value = stored.genre
+            _keyPref.value = stored.key
+            _tempo.value = stored.tempo
+            _duration.value = stored.duration
+        }
+    }
+
+    fun setGenre(value: String) {
+        _genre.value = value
+        viewModelScope.launch { prefs.setGenre(value) }
+    }
+
+    fun setKey(value: String) {
+        _keyPref.value = value
+        viewModelScope.launch { prefs.setKey(value) }
+    }
+
+    fun setTempo(value: Float) {
+        _tempo.value = value
+        viewModelScope.launch { prefs.setTempo(value) }
+    }
+
+    fun setDuration(value: Int) {
+        _duration.value = value
+        viewModelScope.launch { prefs.setDuration(value) }
+    }
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModelFactory.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModelFactory.kt
@@ -8,7 +8,10 @@ object MusicViewModelFactory : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MusicViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return MusicViewModel(ServiceLocator.repository) as T
+            return MusicViewModel(
+                ServiceLocator.repository,
+                ServiceLocator.prefsRepository
+            ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/legendai/musichelper/ServiceLocator.kt
+++ b/app/src/main/java/com/legendai/musichelper/ServiceLocator.kt
@@ -1,10 +1,13 @@
 package com.legendai.musichelper
 
+import android.content.Context
 import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
 
 // Simple object providing shared dependencies without DI frameworks
 object ServiceLocator {
+    lateinit var prefsRepository: UserPreferencesRepository
+
     val httpClient: OkHttpClient by lazy {
         val pinner = CertificatePinner.Builder()
             .add(
@@ -17,4 +20,8 @@ object ServiceLocator {
     }
 
     val repository: MusicRepository by lazy { MusicRepository(httpClient) }
+
+    fun init(context: Context) {
+        prefsRepository = UserPreferencesRepository(context.userPreferencesDataStore)
+    }
 }

--- a/app/src/main/java/com/legendai/musichelper/UserPreferences.kt
+++ b/app/src/main/java/com/legendai/musichelper/UserPreferences.kt
@@ -1,0 +1,8 @@
+package com.legendai.musichelper
+
+data class UserPreferences(
+    val genre: String = "rock",
+    val key: String = "C",
+    val tempo: Float = 120f,
+    val duration: Int = 30
+)

--- a/app/src/main/java/com/legendai/musichelper/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/legendai/musichelper/UserPreferencesRepository.kt
@@ -1,0 +1,46 @@
+package com.legendai.musichelper
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+
+class UserPreferencesRepository(
+    private val dataStore: DataStore<Preferences>
+) {
+    private object Keys {
+        val GENRE = stringPreferencesKey("genre")
+        val KEY = stringPreferencesKey("key")
+        val TEMPO = floatPreferencesKey("tempo")
+        val DURATION = intPreferencesKey("duration")
+    }
+
+    suspend fun getPreferences(): UserPreferences {
+        val prefs = dataStore.data.first()
+        return UserPreferences(
+            genre = prefs[Keys.GENRE] ?: "rock",
+            key = prefs[Keys.KEY] ?: "C",
+            tempo = prefs[Keys.TEMPO] ?: 120f,
+            duration = prefs[Keys.DURATION] ?: 30
+        )
+    }
+
+    suspend fun setGenre(value: String) {
+        dataStore.edit { it[Keys.GENRE] = value }
+    }
+
+    suspend fun setKey(value: String) {
+        dataStore.edit { it[Keys.KEY] = value }
+    }
+
+    suspend fun setTempo(value: Float) {
+        dataStore.edit { it[Keys.TEMPO] = value }
+    }
+
+    suspend fun setDuration(value: Int) {
+        dataStore.edit { it[Keys.DURATION] = value }
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -31,10 +31,14 @@ fun MusicScreen(
     val audio by viewModel.audio.collectAsState()
     val clips by viewModel.clips.collectAsState()
     val chords by viewModel.chords.collectAsState()
-    var genre by remember { mutableStateOf("rock") }
-    var key by remember { mutableStateOf(TextFieldValue("C")) }
-    var tempo by remember { mutableStateOf(120f) }
-    var duration by remember { mutableStateOf(30f) }
+    val genre by viewModel.genre.collectAsState()
+    val savedKey by viewModel.key.collectAsState()
+    val tempo by viewModel.tempo.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    var key by remember { mutableStateOf(TextFieldValue(savedKey)) }
+    LaunchedEffect(savedKey) {
+        if (savedKey != key.text) key = TextFieldValue(savedKey)
+    }
     var selectedClips by remember { mutableStateOf(setOf<String>()) }
 
     LaunchedEffect(key.text, genre) {
@@ -82,7 +86,7 @@ fun MusicScreen(
                 ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                     listOf("rock", "jazz_fusion", "EDM").forEach {
                         DropdownMenuItem(text = { Text(it) }, onClick = {
-                            genre = it
+                            viewModel.setGenre(it)
                             expanded = false
                         })
                     }
@@ -92,16 +96,16 @@ fun MusicScreen(
 
             // Tempo slider
             Text(text = "Tempo: ${tempo.toInt()}")
-            Slider(value = tempo, onValueChange = { tempo = it }, valueRange = 60f..180f)
+            Slider(value = tempo, onValueChange = { viewModel.setTempo(it) }, valueRange = 60f..180f)
             Spacer(Modifier.height(8.dp))
 
             // Duration slider
             Text(text = "Duration: ${duration.toInt()}s")
-            Slider(value = duration, onValueChange = { duration = it }, valueRange = 5f..60f)
+            Slider(value = duration.toFloat(), onValueChange = { viewModel.setDuration(it.toInt()) }, valueRange = 5f..60f)
             Spacer(Modifier.height(8.dp))
 
             // Key input
-            TextField(value = key, onValueChange = { key = it }, label = { Text("Key") })
+            TextField(value = key, onValueChange = { key = it; viewModel.setKey(it.text) }, label = { Text("Key") })
             Spacer(Modifier.height(8.dp))
 
             if (chords.isNotEmpty()) {
@@ -117,7 +121,7 @@ fun MusicScreen(
                     context = LocalContext.current,
                     request = GenerateSongRequest(
                         inputs = prompt,
-                        parameters = Parameters(duration = duration.toInt())
+                        parameters = Parameters(duration = duration)
                     ),
                     key = key.text,
                     genre = genre

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelPrefsTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelPrefsTest.kt
@@ -1,0 +1,73 @@
+package com.legendai.musichelper
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import okhttp3.OkHttpClient
+import kotlin.test.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MusicViewModelPrefsTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var context: Context
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var prefsRepo: UserPreferencesRepository
+    private lateinit var viewModel: MusicViewModel
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(mainDispatcherRule.dispatcher + Job())
+        ) { context.preferencesDataStoreFile("prefs_vm") }
+        prefsRepo = UserPreferencesRepository(dataStore)
+        viewModel = MusicViewModel(MusicRepository(OkHttpClient()), prefsRepo)
+    }
+
+    @After
+    fun tearDown() {
+        context.deleteFile("prefs_vm")
+    }
+
+    @Test
+    fun preferencesLoadedAndUpdated() = runTest(mainDispatcherRule.dispatcher) {
+        prefsRepo.setGenre("edm")
+        prefsRepo.setKey("G")
+        prefsRepo.setTempo(100f)
+        prefsRepo.setDuration(40)
+
+        // re-create viewModel to read stored values
+        viewModel = MusicViewModel(MusicRepository(OkHttpClient()), prefsRepo)
+        advanceUntilIdle()
+        assertEquals("edm", viewModel.genre.value)
+        assertEquals("G", viewModel.key.value)
+        assertEquals(100f, viewModel.tempo.value)
+        assertEquals(40, viewModel.duration.value)
+
+        viewModel.setGenre("jazz")
+        viewModel.setKey("D")
+        viewModel.setTempo(80f)
+        viewModel.setDuration(20)
+
+        advanceUntilIdle()
+        val prefs = prefsRepo.getPreferences()
+        assertEquals("jazz", prefs.genre)
+        assertEquals("D", prefs.key)
+        assertEquals(80f, prefs.tempo)
+        assertEquals(20, prefs.duration)
+    }
+}

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
@@ -2,6 +2,11 @@ package com.legendai.musichelper
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -26,6 +31,8 @@ class MusicViewModelTest {
 
     private lateinit var server: MockWebServer
     private lateinit var repository: MusicRepository
+    private lateinit var prefsRepo: UserPreferencesRepository
+    private lateinit var dataStore: androidx.datastore.core.DataStore<Preferences>
     private lateinit var viewModel: MusicViewModel
     private lateinit var context: Context
 
@@ -34,6 +41,10 @@ class MusicViewModelTest {
         server = MockWebServer()
         server.start()
         context = ApplicationProvider.getApplicationContext()
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(mainDispatcherRule.dispatcher + Job())
+        ) { context.preferencesDataStoreFile("test_prefs") }
+        prefsRepo = UserPreferencesRepository(dataStore)
         val client = OkHttpClient.Builder()
             .addInterceptor { chain ->
                 val original = chain.request()
@@ -45,12 +56,13 @@ class MusicViewModelTest {
             }
             .build()
         repository = MusicRepository(client)
-        viewModel = MusicViewModel(repository)
+        viewModel = MusicViewModel(repository, prefsRepo)
     }
 
     @After
     fun tearDown() {
         server.shutdown()
+        context.deleteFile("test_prefs")
     }
 
     @Test

--- a/app/src/test/java/com/legendai/musichelper/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/UserPreferencesRepositoryTest.kt
@@ -1,0 +1,51 @@
+package com.legendai.musichelper
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserPreferencesRepositoryTest {
+    private lateinit var context: Context
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repo: UserPreferencesRepository
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        dataStore = PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(Job())
+        ) { context.preferencesDataStoreFile("prefs_test") }
+        repo = UserPreferencesRepository(dataStore)
+    }
+
+    @After
+    fun tearDown() {
+        context.deleteFile("prefs_test")
+    }
+
+    @Test
+    fun valuesPersistAndRestore() = runTest {
+        repo.setGenre("jazz")
+        repo.setKey("D")
+        repo.setTempo(90f)
+        repo.setDuration(45)
+
+        val restored = repo.getPreferences()
+        assertEquals("jazz", restored.genre)
+        assertEquals("D", restored.key)
+        assertEquals(90f, restored.tempo)
+        assertEquals(45, restored.duration)
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserPreferences` data class and DataStore-backed `UserPreferencesRepository`
- initialize repository in `MusicGenApplication` via `ServiceLocator`
- inject preferences into `MusicViewModel` and expose state flows
- persist user settings from `MusicScreen`
- update factories and tests
- add unit tests for repository and ViewModel preference handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a96a716083318e0be3e9aeb0a508