### PR TITLE
Switch to DataStore for export tracking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation "androidx.activity:activity-compose:1.6.0"
     implementation "com.google.android.exoplayer:exoplayer:2.18.1"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
+    implementation "androidx.datastore:datastore:1.0.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
     implementation "androidx.compose.material3:material3:1.1.0"
     implementation "androidx.compose.material:material-icons-extended:1.4.0"

--- a/app/src/main/java/com/legendai/musichelper/ExportStore.kt
+++ b/app/src/main/java/com/legendai/musichelper/ExportStore.kt
@@ -1,37 +1,63 @@
 package com.legendai.musichelper
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+@Serializable
+private data class ExportEntries(val entries: List<ExportStore.Entry> = emptyList())
+
+private object ExportEntriesSerializer : Serializer<ExportEntries> {
+    override val defaultValue: ExportEntries = ExportEntries()
+
+    override suspend fun readFrom(input: InputStream): ExportEntries {
+        return try {
+            Json.decodeFromString(ExportEntries.serializer(), input.readBytes().decodeToString())
+        } catch (e: Exception) {
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: ExportEntries, output: OutputStream) {
+        output.write(Json.encodeToString(ExportEntries.serializer(), t).toByteArray())
+    }
+}
+
+private val Context.exportsDataStore: DataStore<ExportEntries> by dataStore(
+    fileName = "exports.json",
+    serializer = ExportEntriesSerializer
+)
 
 /**
- * Simple helper for tracking exported files using SharedPreferences.
+ * Helper for tracking exported files using DataStore.
  */
 object ExportStore {
-    private const val PREFS = "exports"
-    private const val KEY_ENTRIES = "entries"
-
+    @Serializable
     data class Entry(val fileName: String, val time: Long)
 
-    fun add(context: Context, fileName: String) {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val set = prefs.getStringSet(KEY_ENTRIES, mutableSetOf())!!.toMutableSet()
-        val entry = "$fileName|${System.currentTimeMillis()}"
-        set.add(entry)
-        prefs.edit().putStringSet(KEY_ENTRIES, set).apply()
+    fun flow(context: Context): Flow<List<Entry>> =
+        context.exportsDataStore.data.map { it.entries.sortedByDescending { e -> e.time } }
+
+    suspend fun add(context: Context, fileName: String) {
+        context.exportsDataStore.updateData { current ->
+            current.copy(entries = current.entries + Entry(fileName, System.currentTimeMillis()))
+        }
     }
 
-    fun list(context: Context): List<Entry> {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val set = prefs.getStringSet(KEY_ENTRIES, emptySet()) ?: emptySet()
-        return set.mapNotNull {
-            val parts = it.split('|', limit = 2)
-            if (parts.size == 2) Entry(parts[0], parts[1].toLong()) else null
-        }.sortedByDescending { it.time }
-    }
+    suspend fun list(context: Context): List<Entry> =
+        context.exportsDataStore.data.first().entries.sortedByDescending { it.time }
 
-    fun remove(context: Context, fileName: String) {
-        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-        val set = prefs.getStringSet(KEY_ENTRIES, mutableSetOf())!!.toMutableSet()
-        set.removeIf { it.startsWith("$fileName|") }
-        prefs.edit().putStringSet(KEY_ENTRIES, set).apply()
+    suspend fun remove(context: Context, fileName: String) {
+        context.exportsDataStore.updateData { current ->
+            current.copy(entries = current.entries.filterNot { it.fileName == fileName })
+        }
     }
 }

--- a/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.legendai.musichelper.ExportStore
+import kotlinx.coroutines.launch
 import android.content.Intent
 import androidx.core.content.FileProvider
 import java.io.File
@@ -21,7 +22,8 @@ import java.text.DateFormat
 @Composable
 fun ExportsScreen(onDone: () -> Unit) {
     val context = LocalContext.current
-    var exports by remember { mutableStateOf(ExportStore.list(context)) }
+    val scope = rememberCoroutineScope()
+    val exports by ExportStore.flow(context).collectAsState(initial = emptyList())
 
     Scaffold(
         topBar = {
@@ -65,9 +67,10 @@ fun ExportsScreen(onDone: () -> Unit) {
                             Icon(Icons.Default.Share, contentDescription = null)
                         }
                         IconButton(onClick = {
-                            file.delete()
-                            ExportStore.remove(context, entry.fileName)
-                            exports = ExportStore.list(context)
+                            scope.launch {
+                                file.delete()
+                                ExportStore.remove(context, entry.fileName)
+                            }
                         }) {
                             Icon(Icons.Default.Delete, contentDescription = null)
                         }

--- a/app/src/test/java/com/legendai/musichelper/ExportStoreTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/ExportStoreTest.kt
@@ -2,9 +2,12 @@ package com.legendai.musichelper
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -14,29 +17,29 @@ class ExportStoreTest {
     @Before
     fun setup() {
         context = ApplicationProvider.getApplicationContext()
-        context.deleteSharedPreferences("exports")
+        File(context.filesDir, "datastore/exports.json").delete()
     }
 
     @After
     fun tearDown() {
-        context.deleteSharedPreferences("exports")
+        File(context.filesDir, "datastore/exports.json").delete()
     }
 
     @Test
-    fun addStoresEntry() {
+    fun addStoresEntry() = runTest {
         ExportStore.add(context, "one.wav")
 
-        val prefs = context.getSharedPreferences("exports", Context.MODE_PRIVATE)
-        val entries = prefs.getStringSet("entries", emptySet())!!
+        val list = ExportStore.list(context)
 
-        assertEquals(1, entries.size)
-        assertTrue(entries.first().startsWith("one.wav|"))
+        assertEquals(1, list.size)
+        assertEquals("one.wav", list[0].fileName)
+        assertTrue(list[0].time > 0)
     }
 
     @Test
-    fun listReturnsEntriesSorted() {
+    fun listReturnsEntriesSorted() = runTest {
         ExportStore.add(context, "first.wav")
-        Thread.sleep(10)
+        delay(10)
         ExportStore.add(context, "second.wav")
 
         val list = ExportStore.list(context)
@@ -48,19 +51,17 @@ class ExportStoreTest {
     }
 
     @Test
-    fun listParsesPipeSeparatedEntries() {
-        val prefs = context.getSharedPreferences("exports", Context.MODE_PRIVATE)
-        prefs.edit().putStringSet("entries", setOf("file|name.wav|123"))!!.apply()
+    fun addFileNameWithPipe() = runTest {
+        ExportStore.add(context, "file|name.wav")
 
         val list = ExportStore.list(context)
 
         assertEquals(1, list.size)
         assertEquals("file|name.wav", list[0].fileName)
-        assertEquals(123, list[0].time)
     }
 
     @Test
-    fun removeDeletesEntry() {
+    fun removeDeletesEntry() = runTest {
         ExportStore.add(context, "a.wav")
         ExportStore.add(context, "b.wav")
 


### PR DESCRIPTION
## Summary
- replace SharedPreferences with DataStore JSON storage for exports
- expose a Flow of export entries and suspend add/list/remove
- collect the Flow in `ExportsScreen`
- update tests for DataStore usage
- add DataStore dependency

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a97057c88331a67d94aa5b56d0fa