### PR TITLE
Add network connectivity checks

### DIFF
--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import com.legendai.musichelper.util.ChordGenerator
 import com.legendai.musichelper.util.AudioMixer
+import com.legendai.musichelper.util.NetworkUtils
 
 // ViewModel handling business logic and exposing Compose states
 class MusicViewModel(
@@ -39,6 +40,10 @@ class MusicViewModel(
         val apiKey = Config.getApiKey(context)
         if (apiKey.isBlank()) {
             _error.value = "Please set your API key in Settings"
+            return
+        }
+        if (!NetworkUtils.isConnected(context)) {
+            _error.value = "No internet connection"
             return
         }
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/legendai/musichelper/util/NetworkUtils.kt
+++ b/app/src/main/java/com/legendai/musichelper/util/NetworkUtils.kt
@@ -1,0 +1,22 @@
+package com.legendai.musichelper.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+
+object NetworkUtils {
+    fun isConnected(context: Context): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return false
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = cm.activeNetwork ?: return false
+            val caps = cm.getNetworkCapabilities(network) ?: return false
+            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                    caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        } else {
+            @Suppress("DEPRECATION")
+            val info = cm.activeNetworkInfo
+            info != null && info.isConnected
+        }
+    }
+}

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
@@ -98,6 +98,22 @@ class MusicViewModelTest {
     }
 
     @Test
+    fun generateSong_offline_setsError() = runTest(mainDispatcherRule.dispatcher) {
+        val offline = object : android.content.ContextWrapper(context) {
+            override fun getSystemService(name: String): Any? {
+                return if (name == android.content.Context.CONNECTIVITY_SERVICE) null else super.getSystemService(name)
+            }
+        }
+
+        viewModel.generateSong(offline, GenerateSongRequest("prompt"), "C", "rock")
+        advanceUntilIdle()
+
+        assertEquals(0f, viewModel.progress.value)
+        assertNull(viewModel.audio.value)
+        assertEquals("No internet connection", viewModel.error.value)
+    }
+
+    @Test
     fun mixdownAndExport_nullDir_setsError() = runTest(mainDispatcherRule.dispatcher) {
         val audio = File.createTempFile("clip_", ".wav")
         val wrapper = object : android.content.ContextWrapper(context) {


### PR DESCRIPTION
## Summary
- add `NetworkUtils` helper using `ConnectivityManager`
- check connectivity in `MusicViewModel` before generating a song
- emit "No internet connection" error when offline
- add unit test for offline scenario

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a97285408331b28c7ec9ec0e6be7