### PR TITLE
Add clip delete/rename

### DIFF
--- a/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlin.test.assertNull
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -69,5 +70,22 @@ class MainActivityTest {
             error = viewModel.error.value
         }
         assertNull(error)
+    }
+
+    @Test
+    fun deleteClip_removesRow() {
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            val viewModel = ViewModelProvider(activity)[MusicViewModel::class.java]
+            val cache = activity.cacheDir
+            val file = java.io.File(cache, "clip.wav").apply { writeText("data") }
+            val field = viewModel.javaClass.getDeclaredField("_clips")
+            field.isAccessible = true
+            val state = field.get(viewModel) as MutableStateFlow<List<GenerateSongResponse>>
+            state.value = listOf(GenerateSongResponse(file.absolutePath))
+        }
+
+        composeTestRule.onNodeWithContentDescription("Delete").performClick()
+
+        composeTestRule.onNodeWithText("Clip 1").assertDoesNotExist()
     }
 }

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -104,4 +104,28 @@ class MusicViewModel(
             }
         }
     }
+
+    fun deleteClip(response: GenerateSongResponse) {
+        File(response.audioPath).delete()
+        _clips.value = _clips.value.filterNot { it.audioPath == response.audioPath }
+    }
+
+    fun renameClip(response: GenerateSongResponse, newName: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val file = File(response.audioPath)
+                val newFile = File(file.parentFile, newName)
+                if (file.renameTo(newFile)) {
+                    val updated = GenerateSongResponse(newFile.absolutePath)
+                    _clips.value = _clips.value.map {
+                        if (it.audioPath == response.audioPath) updated else it
+                    }
+                } else {
+                    _error.value = "File error—please retry"
+                }
+            } catch (e: Exception) {
+                _error.value = "File error—please retry"
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -3,6 +3,8 @@ package com.legendai.musichelper.ui
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.layout.*
@@ -15,9 +17,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import java.io.File
 import com.legendai.musichelper.GenerateSongRequest
 import com.legendai.musichelper.Parameters
 import com.legendai.musichelper.MusicViewModel
+import com.legendai.musichelper.GenerateSongResponse
 // Exporting to the app specific external directory does not require
 // runtime storage permission, so no permission APIs are needed here.
 @Composable
@@ -36,6 +40,8 @@ fun MusicScreen(
     var tempo by remember { mutableStateOf(120f) }
     var duration by remember { mutableStateOf(30f) }
     var selectedClips by remember { mutableStateOf(setOf<String>()) }
+    var renameTarget by remember { mutableStateOf<com.legendai.musichelper.GenerateSongResponse?>(null) }
+    var renameText by remember { mutableStateOf(TextFieldValue("")) }
 
     LaunchedEffect(key.text, genre) {
         viewModel.updateChords(key.text, genre)
@@ -158,6 +164,12 @@ fun MusicScreen(
                         Button(onClick = {
                             viewModel.mixdownAndExport(LocalContext.current, clip)
                         }) { Text("Export") }
+                        IconButton(onClick = { renameTarget = clip; renameText = TextFieldValue(java.io.File(clip.audioPath).name) }) {
+                            Icon(Icons.Default.Edit, contentDescription = "Rename")
+                        }
+                        IconButton(onClick = { viewModel.deleteClip(clip) }) {
+                            Icon(Icons.Default.Delete, contentDescription = "Delete")
+                        }
                     }
                     Spacer(Modifier.height(8.dp))
                 }
@@ -168,6 +180,25 @@ fun MusicScreen(
                     val selected = clips.filter { selectedClips.contains(it.audioPath) }
                     viewModel.mixAndExport(LocalContext.current, selected)
                 }) { Text("Mix & Export") }
+            }
+
+            renameTarget?.let { target ->
+                AlertDialog(
+                    onDismissRequest = { renameTarget = null },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.renameClip(target, renameText.text)
+                            renameTarget = null
+                        }) { Text("OK") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { renameTarget = null }) { Text("Cancel") }
+                    },
+                    title = { Text("Rename Clip") },
+                    text = {
+                        TextField(value = renameText, onValueChange = { renameText = it })
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend `MusicScreen` with Rename/Delete actions and dialog
- update `MusicViewModel` with `deleteClip` and `renameClip`
- expand UI tests to cover removing a clip

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a9749e08833194f1273a189c8af4