### PR TITLE
Add navigation compose and bottom bar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
     implementation "androidx.compose.material3:material3:1.1.0"
     implementation "androidx.compose.material:material-icons-extended:1.4.0"
+    implementation "androidx.navigation:navigation-compose:2.7.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"

--- a/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
@@ -19,7 +19,7 @@ class MainActivityTest {
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     @Test
-    fun openSettings_displaysSettingsScreen() {
+    fun openSettings_viaBottomBar_displaysSettingsScreen() {
         composeTestRule.onNodeWithContentDescription("Settings").performClick()
         composeTestRule.onNodeWithText("Hugging Face API Key").assertIsDisplayed()
     }

--- a/app/src/main/java/com/legendai/musichelper/MainActivity.kt
+++ b/app/src/main/java/com/legendai/musichelper/MainActivity.kt
@@ -3,26 +3,39 @@ package com.legendai.musichelper
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.*
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.legendai.musichelper.ui.ExportsScreen
 import com.legendai.musichelper.ui.MusicScreen
 import com.legendai.musichelper.ui.SettingsScreen
-import com.legendai.musichelper.ui.ExportsScreen
 import com.legendai.musichelper.ui.theme.MusicGenTheme
+
+sealed class Destination(val route: String, val icon: ImageVector, val label: String) {
+    object Create : Destination("create", Icons.Default.MusicNote, "Create")
+    object Exports : Destination("exports", Icons.Default.List, "Exports")
+    object Settings : Destination("settings", Icons.Default.Settings, "Settings")
+}
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             val viewModel: MusicViewModel = viewModel(factory = MusicViewModelFactory)
-            var showSettings by remember { mutableStateOf(false) }
-            var showExports by remember { mutableStateOf(false) }
+            val navController = rememberNavController()
             MusicGenTheme {
                 val snackbarHostState = remember { SnackbarHostState() }
                 val error by viewModel.error.collectAsStateWithLifecycle()
@@ -32,15 +45,40 @@ class MainActivity : ComponentActivity() {
                         viewModel.clearError()
                     }
                 }
-                when {
-                    showSettings -> SettingsScreen { showSettings = false }
-                    showExports -> ExportsScreen { showExports = false }
-                    else -> MusicScreen(
-                        viewModel,
-                        snackbarHostState,
-                        onOpenSettings = { showSettings = true },
-                        onOpenExports = { showExports = true }
-                    )
+                val items = listOf(Destination.Create, Destination.Exports, Destination.Settings)
+                Scaffold(
+                    snackbarHost = { SnackbarHost(snackbarHostState) },
+                    bottomBar = {
+                        NavigationBar {
+                            val currentBackStackEntry by navController.currentBackStackEntryAsState()
+                            val currentRoute = currentBackStackEntry?.destination?.route
+                            items.forEach { dest ->
+                                NavigationBarItem(
+                                    selected = currentRoute == dest.route,
+                                    onClick = {
+                                        navController.navigate(dest.route) {
+                                            popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        }
+                                    },
+                                    icon = { Icon(dest.icon, contentDescription = dest.label) },
+                                    label = { Text(dest.label) }
+                                )
+                            }
+                        }
+                    },
+                    containerColor = MaterialTheme.colorScheme.background
+                ) { padding ->
+                    NavHost(
+                        navController = navController,
+                        startDestination = Destination.Create.route,
+                        modifier = Modifier.padding(padding)
+                    ) {
+                        composable(Destination.Create.route) { MusicScreen(viewModel, snackbarHostState) }
+                        composable(Destination.Settings.route) { SettingsScreen() }
+                        composable(Destination.Exports.route) { ExportsScreen() }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.*
@@ -19,20 +18,13 @@ import java.io.File
 import java.text.DateFormat
 
 @Composable
-fun ExportsScreen(onDone: () -> Unit) {
+fun ExportsScreen() {
     val context = LocalContext.current
     var exports by remember { mutableStateOf(ExportStore.list(context)) }
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Exports") },
-                navigationIcon = {
-                    IconButton(onClick = onDone) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = null)
-                    }
-                }
-            )
+            TopAppBar(title = { Text("Exports") })
         }
     ) { padding ->
         LazyColumn(modifier = Modifier.padding(padding)) {

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -1,8 +1,5 @@
 package com.legendai.musichelper.ui
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.List
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.layout.*
@@ -24,8 +21,6 @@ import com.legendai.musichelper.MusicViewModel
 fun MusicScreen(
     viewModel: MusicViewModel,
     snackbarHostState: SnackbarHostState,
-    onOpenSettings: () -> Unit = {},
-    onOpenExports: () -> Unit = {}
 ) {
     val progress by viewModel.progress.collectAsState()
     val audio by viewModel.audio.collectAsState()
@@ -44,20 +39,7 @@ fun MusicScreen(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopAppBar(
-                title = { Text("MusicGen Helper") },
-                actions = {
-                    IconButton(onClick = onOpenExports) {
-                        Icon(Icons.Default.List, contentDescription = null)
-                    }
-                    IconButton(onClick = onOpenSettings) {
-                        Icon(
-                            Icons.Default.Settings,
-                            contentDescription = "Settings"
-                        )
-                    }
-                }
-            )
+            TopAppBar(title = { Text("MusicGen Helper") })
         },
         containerColor = MaterialTheme.colorScheme.background
     ) { padding ->

--- a/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
@@ -1,8 +1,6 @@
 package com.legendai.musichelper.ui
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -11,20 +9,13 @@ import androidx.compose.ui.unit.dp
 import com.legendai.musichelper.Config
 
 @Composable
-fun SettingsScreen(onDone: () -> Unit) {
+fun SettingsScreen() {
     val context = LocalContext.current
     var apiKey by remember { mutableStateOf(Config.getApiKey(context)) }
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Settings") },
-                navigationIcon = {
-                    IconButton(onClick = onDone) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = null)
-                    }
-                }
-            )
+            TopAppBar(title = { Text("Settings") })
         }
     ) { padding ->
         Column(
@@ -42,7 +33,6 @@ fun SettingsScreen(onDone: () -> Unit) {
             Spacer(Modifier.height(16.dp))
             Button(onClick = {
                 Config.setApiKey(context, apiKey)
-                onDone()
             }) {
                 Text("Save")
             }


### PR DESCRIPTION
## Summary
- add navigation-compose dependency
- rework `MainActivity` to use `NavHost` and bottom navigation
- simplify `MusicScreen`, `SettingsScreen` and `ExportsScreen`
- adjust tests for new bottom-bar navigation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a96cb5d08331a4e16ca92caa4433