### PR TITLE
Fix compile errors and tests; remove Gradle wrapper jar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
     implementation "androidx.datastore:datastore:1.0.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0"
     implementation "androidx.compose.material3:material3:1.1.0"
     implementation "androidx.compose.material:material-icons-extended:1.4.0"
     implementation "androidx.datastore:datastore-preferences:1.0.0"

--- a/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/legendai/musichelper/MainActivityTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.legendai.musichelper.Config
 import kotlin.test.assertNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import androidx.lifecycle.ViewModelProvider
@@ -26,6 +27,9 @@ class MainActivityTest {
 
     @Test
     fun generateSong_showsErrorSnackbar() {
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            Config.setApiKey(activity, "dummy")
+        }
         composeTestRule.onNodeWithText("Generate Song").performClick()
         composeTestRule.onNodeWithText("Network error—please retry").assertIsDisplayed()
     }

--- a/app/src/main/java/com/legendai/musichelper/MainActivity.kt
+++ b/app/src/main/java/com/legendai/musichelper/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.legendai.musichelper.ui.MusicScreen

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelPrefsTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelPrefsTest.kt
@@ -40,7 +40,7 @@ class MusicViewModelPrefsTest {
 
     @After
     fun tearDown() {
-        context.deleteFile("prefs_vm")
+        context.preferencesDataStoreFile("prefs_vm").delete()
     }
 
     @Test

--- a/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/MusicViewModelTest.kt
@@ -62,7 +62,7 @@ class MusicViewModelTest {
     @After
     fun tearDown() {
         server.shutdown()
-        context.deleteFile("test_prefs")
+        context.preferencesDataStoreFile("test_prefs").delete()
     }
 
     @Test

--- a/app/src/test/java/com/legendai/musichelper/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/UserPreferencesRepositoryTest.kt
@@ -32,7 +32,7 @@ class UserPreferencesRepositoryTest {
 
     @After
     fun tearDown() {
-        context.deleteFile("prefs_test")
+        context.preferencesDataStoreFile("prefs_test").delete()
     }
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- add missing `setValue` import in `MainActivity`
- include lifecycle runtime compose dependency
- clean up DataStore files in tests
- store API key in `MainActivityTest`
- remove `gradle-wrapper.jar` to avoid binary file in PR

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842afcacbcc833194beae57a7db5c2b