### PR TITLE
Remove Robolectric from tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
     testImplementation "androidx.test:core:1.5.0"
-    testImplementation "org.robolectric:robolectric:4.10.3"
 
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"


### PR DESCRIPTION
## Summary
- remove the Robolectric dependency from unit tests

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684328052c7483319344c8882a0d0571