### PR TITLE
Add Spotify tab generation support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,9 @@ android {
 
         def apiKey = project.hasProperty('musicgenApiKey') ? project.property('musicgenApiKey') : ""
         buildConfigField "String", "MUSICGEN_API_KEY", '"' + apiKey + '"'
+
+        def spotifyKey = project.hasProperty('spotifyApiKey') ? project.property('spotifyApiKey') : ""
+        buildConfigField "String", "SPOTIFY_API_KEY", '"' + spotifyKey + '"'
     }
 
     buildFeatures {

--- a/app/src/main/java/com/legendai/musichelper/Config.kt
+++ b/app/src/main/java/com/legendai/musichelper/Config.kt
@@ -8,6 +8,7 @@ import com.legendai.musichelper.BuildConfig
 // Configuration values such as API base URL and API key loader
 object Config {
     const val API_BASE_URL = "https://api-inference.huggingface.co/"
+    const val SPOTIFY_BASE_URL = "https://api.spotify.com/v1/"
 
     fun getApiKey(context: Context): String {
         if (BuildConfig.MUSICGEN_API_KEY.isNotBlank()) {
@@ -42,5 +43,38 @@ object Config {
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
         prefs.edit().putString("API_KEY", apiKey).apply()
+    }
+
+    fun getSpotifyApiKey(context: Context): String {
+        if (BuildConfig.SPOTIFY_API_KEY.isNotBlank()) {
+            return BuildConfig.SPOTIFY_API_KEY
+        }
+        System.getenv("SPOTIFY_API_KEY")?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        val prefs = EncryptedSharedPreferences.create(
+            context,
+            "legend_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+        return prefs.getString("SPOTIFY_KEY", "") ?: ""
+    }
+
+    fun setSpotifyApiKey(context: Context, apiKey: String) {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        val prefs = EncryptedSharedPreferences.create(
+            context,
+            "legend_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+        prefs.edit().putString("SPOTIFY_KEY", apiKey).apply()
     }
 }

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModel.kt
@@ -11,12 +11,15 @@ import kotlinx.coroutines.launch
 import com.legendai.musichelper.util.ChordGenerator
 import com.legendai.musichelper.util.AudioMixer
 import com.legendai.musichelper.util.MelodyGenerator
+import com.legendai.musichelper.util.TabGenerator
 import com.legendai.musichelper.UserPreferencesRepository
+import com.legendai.musichelper.spotify.SpotifyService
 
 // ViewModel handling business logic and exposing Compose states
 class MusicViewModel(
     private val repository: MusicRepository,
     private val prefs: UserPreferencesRepository,
+    private val spotify: SpotifyService,
 ) : ViewModel() {
 
     private val _progress = MutableStateFlow(0f)
@@ -42,6 +45,9 @@ class MusicViewModel(
 
     private val _melody = MutableStateFlow<List<String>>(emptyList())
     val melody: StateFlow<List<String>> = _melody
+
+    private val _tabs = MutableStateFlow<List<String>>(emptyList())
+    val tabs: StateFlow<List<String>> = _tabs
 
     init {
         viewModelScope.launch {
@@ -115,6 +121,26 @@ class MusicViewModel(
 
     fun generateMelody(key: String, instrument: MelodyGenerator.Instrument) {
         _melody.value = MelodyGenerator.generate(key, instrument = instrument)
+    }
+
+    fun generateTabs(context: Context, query: String, instrument: MelodyGenerator.Instrument) {
+        val key = Config.getSpotifyApiKey(context)
+        if (key.isBlank()) {
+            _error.value = "Please set your Spotify API key in Settings"
+            return
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val track = spotify.searchAndAnalyze(key, query)
+                if (track == null) {
+                    _error.value = "Track not found"
+                    return@launch
+                }
+                _tabs.value = TabGenerator.generate(track, instrument)
+            } catch (e: Exception) {
+                _error.value = "Spotify error"
+            }
+        }
     }
     fun mixdownAndExport(context: Context, response: GenerateSongResponse) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/legendai/musichelper/MusicViewModelFactory.kt
+++ b/app/src/main/java/com/legendai/musichelper/MusicViewModelFactory.kt
@@ -10,7 +10,8 @@ object MusicViewModelFactory : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             return MusicViewModel(
                 ServiceLocator.repository,
-                ServiceLocator.prefsRepository
+                ServiceLocator.prefsRepository,
+                ServiceLocator.spotifyService
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")

--- a/app/src/main/java/com/legendai/musichelper/ServiceLocator.kt
+++ b/app/src/main/java/com/legendai/musichelper/ServiceLocator.kt
@@ -3,6 +3,7 @@ package com.legendai.musichelper
 import android.content.Context
 import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
+import com.legendai.musichelper.spotify.SpotifyService
 
 // Simple object providing shared dependencies without DI frameworks
 object ServiceLocator {
@@ -20,6 +21,7 @@ object ServiceLocator {
     }
 
     val repository: MusicRepository by lazy { MusicRepository(httpClient) }
+    val spotifyService: SpotifyService by lazy { SpotifyService(httpClient) }
 
     fun init(context: Context) {
         prefsRepository = UserPreferencesRepository(context.userPreferencesDataStore)

--- a/app/src/main/java/com/legendai/musichelper/spotify/SpotifyService.kt
+++ b/app/src/main/java/com/legendai/musichelper/spotify/SpotifyService.kt
@@ -1,0 +1,53 @@
+package com.legendai.musichelper.spotify
+
+import com.legendai.musichelper.Config
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.net.URLEncoder
+
+class SpotifyService(
+    private val client: OkHttpClient,
+    private val baseUrl: String = Config.SPOTIFY_BASE_URL
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Throws(IOException::class)
+    fun searchAndAnalyze(apiKey: String, query: String): SpotifyTrack? {
+        val searchUrl = baseUrl + "search?q=" +
+            URLEncoder.encode(query, "UTF-8") + "&type=track&limit=1"
+        val searchReq = Request.Builder()
+            .url(searchUrl)
+            .addHeader("Authorization", "Bearer $apiKey")
+            .build()
+        val track = client.newCall(searchReq).execute().use { resp ->
+            if (!resp.isSuccessful) throw IOException("Search failed")
+            val root = json.parseToJsonElement(resp.body!!.string()).jsonObject
+            val item = root["tracks"]?.jsonObject?.get("items")?.jsonArray
+                ?.firstOrNull()?.jsonObject ?: return null
+            val id = item["id"]!!.jsonPrimitive.content
+            val name = item["name"]!!.jsonPrimitive.content
+            val artist = item["artists"]!!.jsonArray
+                .first().jsonObject["name"]!!.jsonPrimitive.content
+            SpotifyTrack(id = id, name = name, artist = artist)
+        } ?: return null
+
+        val featuresUrl = baseUrl + "audio-features/" + track.id
+        val featuresReq = Request.Builder()
+            .url(featuresUrl)
+            .addHeader("Authorization", "Bearer $apiKey")
+            .build()
+        return client.newCall(featuresReq).execute().use { resp ->
+            if (!resp.isSuccessful) throw IOException("Features failed")
+            val root = json.parseToJsonElement(resp.body!!.string()).jsonObject
+            track.copy(
+                tempo = root["tempo"]?.jsonPrimitive?.float,
+                key = root["key"]?.jsonPrimitive?.int,
+                mode = root["mode"]?.jsonPrimitive?.int
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/legendai/musichelper/spotify/SpotifyTrack.kt
+++ b/app/src/main/java/com/legendai/musichelper/spotify/SpotifyTrack.kt
@@ -1,0 +1,10 @@
+package com.legendai.musichelper.spotify
+
+data class SpotifyTrack(
+    val id: String,
+    val name: String,
+    val artist: String,
+    val tempo: Float? = null,
+    val key: Int? = null,
+    val mode: Int? = null
+)

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -38,6 +38,7 @@ fun MusicScreen(
     val tempo by viewModel.tempo.collectAsState()
     val duration by viewModel.duration.collectAsState()
     val melody by viewModel.melody.collectAsState()
+    val tabs by viewModel.tabs.collectAsState()
     var key by remember { mutableStateOf(TextFieldValue(savedKey)) }
     LaunchedEffect(savedKey) {
         if (savedKey != key.text) key = TextFieldValue(savedKey)
@@ -45,6 +46,9 @@ fun MusicScreen(
     var selectedClips by remember { mutableStateOf(setOf<String>()) }
     var instrumentExpanded by remember { mutableStateOf(false) }
     var instrument by remember { mutableStateOf(MelodyGenerator.Instrument.GUITAR) }
+    var tabInstrumentExpanded by remember { mutableStateOf(false) }
+    var tabInstrument by remember { mutableStateOf(MelodyGenerator.Instrument.GUITAR) }
+    var search by remember { mutableStateOf(TextFieldValue("")) }
 
     LaunchedEffect(key.text, genre) {
         viewModel.updateChords(key.text, genre)
@@ -132,6 +136,10 @@ fun MusicScreen(
                         instrument = MelodyGenerator.Instrument.GUITAR
                         instrumentExpanded = false
                     })
+                    DropdownMenuItem(text = { Text("Bass") }, onClick = {
+                        instrument = MelodyGenerator.Instrument.BASS
+                        instrumentExpanded = false
+                    })
                     DropdownMenuItem(text = { Text("Keyboard") }, onClick = {
                         instrument = MelodyGenerator.Instrument.KEYBOARD
                         instrumentExpanded = false
@@ -144,6 +152,48 @@ fun MusicScreen(
 
             if (melody.isNotEmpty()) {
                 melody.forEach { line ->
+                    Text(line, fontFamily = FontFamily.Monospace)
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+
+            TextField(
+                value = search,
+                onValueChange = { search = it },
+                label = { Text("Song search") }
+            )
+            Spacer(Modifier.height(8.dp))
+
+            ExposedDropdownMenuBox(expanded = tabInstrumentExpanded, onExpandedChange = { tabInstrumentExpanded = !tabInstrumentExpanded }) {
+                TextField(
+                    value = tabInstrument.name.lowercase().replaceFirstChar { it.uppercase() },
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Tab Instrument") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = tabInstrumentExpanded) },
+                    modifier = Modifier.menuAnchor()
+                )
+                ExposedDropdownMenu(expanded = tabInstrumentExpanded, onDismissRequest = { tabInstrumentExpanded = false }) {
+                    DropdownMenuItem(text = { Text("Guitar") }, onClick = {
+                        tabInstrument = MelodyGenerator.Instrument.GUITAR
+                        tabInstrumentExpanded = false
+                    })
+                    DropdownMenuItem(text = { Text("Bass") }, onClick = {
+                        tabInstrument = MelodyGenerator.Instrument.BASS
+                        tabInstrumentExpanded = false
+                    })
+                    DropdownMenuItem(text = { Text("Keyboard") }, onClick = {
+                        tabInstrument = MelodyGenerator.Instrument.KEYBOARD
+                        tabInstrumentExpanded = false
+                    })
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+
+            Button(onClick = { viewModel.generateTabs(LocalContext.current, search.text, tabInstrument) }) { Text("Generate Tabs") }
+
+            if (tabs.isNotEmpty()) {
+                tabs.forEach { line ->
                     Text(line, fontFamily = FontFamily.Monospace)
                 }
                 Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
@@ -14,6 +14,7 @@ import com.legendai.musichelper.Config
 fun SettingsScreen(onDone: () -> Unit) {
     val context = LocalContext.current
     var apiKey by remember { mutableStateOf(Config.getApiKey(context)) }
+    var spotifyKey by remember { mutableStateOf(Config.getSpotifyApiKey(context)) }
 
     Scaffold(
         topBar = {
@@ -40,8 +41,16 @@ fun SettingsScreen(onDone: () -> Unit) {
                 modifier = Modifier.fillMaxWidth()
             )
             Spacer(Modifier.height(16.dp))
+            TextField(
+                value = spotifyKey,
+                onValueChange = { spotifyKey = it },
+                label = { Text("Spotify API Key") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(16.dp))
             Button(onClick = {
                 Config.setApiKey(context, apiKey)
+                Config.setSpotifyApiKey(context, spotifyKey)
                 onDone()
             }) {
                 Text("Save")

--- a/app/src/main/java/com/legendai/musichelper/util/MelodyGenerator.kt
+++ b/app/src/main/java/com/legendai/musichelper/util/MelodyGenerator.kt
@@ -8,7 +8,7 @@ import kotlin.random.Random
  * to avoid adding external dependencies.
  */
 object MelodyGenerator {
-    enum class Instrument { GUITAR, KEYBOARD }
+    enum class Instrument { GUITAR, KEYBOARD, BASS }
 
     private val chromatic = listOf(
         "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"
@@ -39,9 +39,11 @@ object MelodyGenerator {
     private fun scaleIntervals(minor: Boolean) =
         if (minor) intArrayOf(0,2,3,5,7,8,10) else intArrayOf(0,2,4,5,7,9,11)
 
-    // ----- Guitar specific helpers -----
+    // ----- Guitar/Bass specific helpers -----
     private val tuning = listOf("E4", "B3", "G3", "D3", "A2", "E2") // high to low
     private val tuningIdx = tuning.map { noteIndex(it) }
+    private val bassTuning = listOf("G2", "D2", "A1", "E1")
+    private val bassTuningIdx = bassTuning.map { noteIndex(it) }
 
     private fun noteIndex(note: String): Int {
         val m = Regex("([A-G]#?)(\\d)").matchEntire(note) ?: return 0
@@ -80,6 +82,35 @@ object MelodyGenerator {
         return lines.indices.map { names[it] + lines[it].toString() }
     }
 
+    private fun generateBassTab(root: Int, minor: Boolean, length: Int): List<String> {
+        val scale = scaleIntervals(minor).map { (root + it) % 12 }
+        val lines = MutableList(4) { StringBuilder() }
+        repeat(length) {
+            val degree = scale.random()
+            val octave = 2 + Random.nextInt(0,2)
+            val pitch = degree + octave*12
+            val (stringIdx, fret) = findBassStringAndFret(pitch)
+            for (i in 0 until 4) {
+                if (i == stringIdx) {
+                    lines[i].append(fret.toString().padStart(2,'-')).append("-")
+                } else {
+                    lines[i].append("---")
+                }
+            }
+        }
+        val names = listOf("G|","D|","A|","E|")
+        return lines.indices.map { names[it] + lines[it].toString() }
+    }
+
+    private fun findBassStringAndFret(pitch: Int): Pair<Int, Int> {
+        for (i in bassTuningIdx.indices) {
+            val fret = pitch - bassTuningIdx[i]
+            if (fret in 0..12) return i to fret
+        }
+        val fret = (pitch - bassTuningIdx[0]).coerceIn(0,12)
+        return 0 to fret
+    }
+
     private fun generateKeyboard(root: Int, minor: Boolean, length: Int): List<String> {
         val scale = scaleIntervals(minor).map { (root + it) % 12 }
         val notes = MutableList(length) {
@@ -98,6 +129,7 @@ object MelodyGenerator {
         return when(instrument) {
             Instrument.GUITAR -> generateGuitarTab(root, minor, length)
             Instrument.KEYBOARD -> generateKeyboard(root, minor, length)
+            Instrument.BASS -> generateBassTab(root, minor, length)
         }
     }
 }

--- a/app/src/main/java/com/legendai/musichelper/util/TabGenerator.kt
+++ b/app/src/main/java/com/legendai/musichelper/util/TabGenerator.kt
@@ -1,0 +1,15 @@
+package com.legendai.musichelper.util
+
+import com.legendai.musichelper.spotify.SpotifyTrack
+
+object TabGenerator {
+    private val names = listOf("C","C#","D","D#","E","F","F#","G","G#","A","A#","B")
+
+    fun generate(track: SpotifyTrack, instrument: MelodyGenerator.Instrument): List<String> {
+        val k = track.key ?: return listOf("Unknown key")
+        val keyStr = names[k % names.size] + if ((track.mode ?: 1) == 0) "m" else ""
+        val chords = ChordGenerator.suggest(keyStr, "rock")
+        val melody = MelodyGenerator.generate(keyStr, instrument = instrument)
+        return listOf("Chords: " + chords.joinToString(" - ")) + melody
+    }
+}

--- a/app/src/test/java/com/legendai/musichelper/spotify/SpotifyServiceTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/spotify/SpotifyServiceTest.kt
@@ -1,0 +1,49 @@
+package com.legendai.musichelper.spotify
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SpotifyServiceTest {
+    private lateinit var server: MockWebServer
+    private lateinit var service: SpotifyService
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+        val client = OkHttpClient.Builder().build()
+        service = SpotifyService(client, baseUrl = server.url("/").toString())
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun searchAndAnalyze_makesRequests() {
+        val searchJson = """
+            {"tracks":{"items":[{"id":"id1","name":"Song","artists":[{"name":"Artist"}]}]}}
+        """.trimIndent()
+        val featuresJson = """
+            {"tempo":120.0,"key":0,"mode":1}
+        """.trimIndent()
+        server.enqueue(MockResponse().setBody(searchJson))
+        server.enqueue(MockResponse().setBody(featuresJson))
+
+        val track = service.searchAndAnalyze("token", "song")
+
+        val req1 = server.takeRequest()
+        assertEquals("/search?q=song&type=track&limit=1", req1.path)
+        val req2 = server.takeRequest()
+        assertEquals("/audio-features/id1", req2.path)
+        assertNotNull(track)
+        assertEquals(120f, track!!.tempo)
+    }
+}

--- a/app/src/test/java/com/legendai/musichelper/util/TabGeneratorTest.kt
+++ b/app/src/test/java/com/legendai/musichelper/util/TabGeneratorTest.kt
@@ -1,0 +1,14 @@
+package com.legendai.musichelper.util
+
+import com.legendai.musichelper.spotify.SpotifyTrack
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class TabGeneratorTest {
+    @Test
+    fun generateFromTrack() {
+        val track = SpotifyTrack("1", "Song", "Artist", tempo = 120f, key = 0, mode = 1)
+        val tab = TabGenerator.generate(track, MelodyGenerator.Instrument.BASS)
+        assertTrue(tab.isNotEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Spotify API key in config and settings
- introduce Spotify service and data model
- generate tabs from Spotify track data
- add bass support to MelodyGenerator
- expose tab generation UI in MusicScreen
- add unit tests for Spotify service and TabGenerator

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432808be9083319dff581e551ccb3a