### PR TITLE
Switch to material3 icon core

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0"
     implementation "androidx.compose.material3:material3:1.1.0"
-    implementation "androidx.compose.material:material-icons-extended:1.4.0"
+    implementation "androidx.compose.material3:material3-icons-core:1.1.0"
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"

--- a/app/src/main/java/com/legendai/musichelper/ui/AudioPlayer.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/AudioPlayer.kt
@@ -1,8 +1,8 @@
 package com.legendai.musichelper.ui
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.Pause
+import androidx.compose.material3.icons.filled.PlayArrow
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/ExportsScreen.kt
@@ -3,10 +3,10 @@ package com.legendai.musichelper.ui
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.ArrowBack
+import androidx.compose.material3.icons.filled.Delete
+import androidx.compose.material3.icons.filled.Share
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/MusicScreen.kt
@@ -1,8 +1,8 @@
 package com.legendai.musichelper.ui
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.List
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.Settings
+import androidx.compose.material3.icons.filled.List
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/legendai/musichelper/ui/SettingsScreen.kt
@@ -1,8 +1,8 @@
 package com.legendai.musichelper.ui
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
## Summary
- use lightweight `material3-icons-core` instead of extended icons
- update imports for material3 icons

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile /workspace/ClockworkOrange/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6843280a618c83318be5a1931cd21758