### PR TITLE
Fix build by reverting Compose versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '2.1.21'
-    id 'org.jetbrains.kotlin.plugin.compose' version '2.1.21'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.10'
 }
 
 android {
@@ -29,7 +28,7 @@ android {
         buildConfig true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '2.0.0'
+        kotlinCompilerExtensionVersion '1.4.0'
     }
     kotlinOptions {
         jvmTarget = '1.8'
@@ -38,14 +37,14 @@ android {
 
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.9.3"
-    implementation "androidx.compose.ui:ui:2025.0.0"
+    implementation "androidx.compose.ui:ui:1.4.0"
     implementation "androidx.activity:activity-compose:1.6.0"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
     implementation "androidx.datastore:datastore:1.0.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.0"
     implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0"
-    implementation "androidx.compose.material3:material3:2025.0.0"
-    implementation "androidx.compose.material:material-icons-extended:2025.0.0"
+    implementation "androidx.compose.material3:material3:1.1.0"
+    implementation "androidx.compose.material:material-icons-extended:1.4.0"
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
@@ -54,6 +53,6 @@ dependencies {
 
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:2025.0.0"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:2025.0.0"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.4.0"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:1.4.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.1'
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
     }
 }
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- revert to Gradle plugin 8.1 and Kotlin 1.8.10
- use Compose 1.4.0 libraries again
- downgrade wrapper to Gradle 8.14

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684336ba01ec8331af95fccc109998eb