### PR TITLE
Add React front-end skeleton

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Music GUI Frontend
+
+This React frontend provides a music composition interface using Tone.js and the WebMIDI API. Run `npm install` then `npm run dev` to start the Vite dev server.
+
+- **WaveformViewer** – displays a waveform with markers.
+- **ChordTimeline** – drag-and-drop chord blocks.
+- **AccompanimentPanel** – sliders for bass/drums/piano levels.
+- **TransportBar** – play/pause/record controls.
+
+The app is designed to connect to the FastAPI backend in this repository for chord suggestions and accompaniment generation.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Music GUI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  setupFilesAfterEnv: ["<rootDir>/setupTests.ts"],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  }
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "music-gui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.0",
+    "@mui/material": "^5.15.0",
+    "react": "^18.2.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
+    "react-dom": "^18.2.0",
+    "tone": "^14.8.39"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.2.1",
+    "@types/jest": "^29.5.11",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0",
+    "ts-jest": "^29.4.0",
+    "typescript": "^5.4.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/setupTests.ts
+++ b/frontend/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import { WaveformViewer } from './components/WaveformViewer';
+import { ChordTimeline } from './components/ChordTimeline';
+import { AccompanimentPanel } from './components/AccompanimentPanel';
+import { TransportBar } from './components/TransportBar';
+import { useChordStream } from './hooks/useChordStream';
+import { useAudioContext } from './hooks/useAudioContext';
+
+export const App = () => {
+  const [dark, setDark] = useState(true);
+  const theme = createTheme({ palette: { mode: dark ? 'dark' : 'light' } });
+  const { events, addEvent } = useChordStream();
+  useAudioContext();
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box display="flex" height="100vh">
+        <Box width={300} p={2} bgcolor="background.paper">
+          <WaveformViewer />
+        </Box>
+        <Box flex={1} p={2}>
+          <ChordTimeline events={events} onMove={() => {}} />
+        </Box>
+        <Box width={300} p={2} bgcolor="background.paper">
+          <AccompanimentPanel />
+        </Box>
+      </Box>
+      <Box position="fixed" bottom={0} width="100%" bgcolor="background.paper">
+        <TransportBar onPlay={() => {}} onPause={() => {}} onRecord={() => {}} />
+      </Box>
+    </ThemeProvider>
+  );
+};
+export default App;

--- a/frontend/src/__tests__/WaveformViewer.test.tsx
+++ b/frontend/src/__tests__/WaveformViewer.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import { WaveformViewer } from '../components/WaveformViewer';
+
+test('renders canvas', () => {
+  const { container } = render(<WaveformViewer />);
+  expect(container.querySelector('canvas')).toBeInTheDocument();
+});

--- a/frontend/src/components/AccompanimentPanel.tsx
+++ b/frontend/src/components/AccompanimentPanel.tsx
@@ -1,0 +1,31 @@
+import Grid from '@mui/material/Grid';
+import Slider from '@mui/material/Slider';
+import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+
+interface ControlProps {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}
+
+const Control = ({ label, value, onChange }: ControlProps) => (
+  <Grid item xs={12} sm={4}>
+    <Typography gutterBottom>{label}</Typography>
+    <Slider value={value} onChange={(_, v) => onChange(v as number)} min={0} max={1} step={0.01} />
+  </Grid>
+);
+
+export const AccompanimentPanel = () => {
+  const [bass, setBass] = useState(0.5);
+  const [drums, setDrums] = useState(0.5);
+  const [piano, setPiano] = useState(0.5);
+
+  return (
+    <Grid container spacing={2} p={2}>
+      <Control label="Bass" value={bass} onChange={setBass} />
+      <Control label="Drums" value={drums} onChange={setDrums} />
+      <Control label="Piano" value={piano} onChange={setPiano} />
+    </Grid>
+  );
+};

--- a/frontend/src/components/ChordTimeline.tsx
+++ b/frontend/src/components/ChordTimeline.tsx
@@ -1,0 +1,55 @@
+import { useRef } from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import { useDrag, useDrop } from 'react-dnd';
+import { ChordEvent } from '../hooks/useChordStream';
+
+export interface ChordTimelineProps {
+  events: ChordEvent[];
+  onMove: (index: number, time: number) => void;
+}
+
+export const ChordTimeline = ({ events, onMove }: ChordTimelineProps) => {
+  const [, drop] = useDrop({ accept: 'CHORD' });
+  return (
+    <Box ref={drop} sx={{ height: 100, position: 'relative', overflow: 'auto' }}>
+      {events.map((evt, idx) => (
+        <ChordBlock key={idx} index={idx} time={evt.time} chord={evt.chord} onMove={onMove} />
+      ))}
+    </Box>
+  );
+};
+
+interface BlockProps {
+  index: number;
+  time: number;
+  chord: string;
+  onMove: (index: number, time: number) => void;
+}
+
+const ChordBlock = ({ index, time, chord, onMove }: BlockProps) => {
+  const [{ isDragging }, drag] = useDrag({
+    type: 'CHORD',
+    item: { index },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() })
+  });
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <Paper
+      ref={drag}
+      sx={{
+        width: 80,
+        height: 40,
+        position: 'absolute',
+        left: time * 80,
+        top: 20,
+        opacity: isDragging ? 0.5 : 1,
+        textAlign: 'center',
+        lineHeight: '40px',
+        cursor: 'move'
+      }}
+    >
+      {chord}
+    </Paper>
+  );
+};

--- a/frontend/src/components/TransportBar.tsx
+++ b/frontend/src/components/TransportBar.tsx
@@ -1,0 +1,37 @@
+import Stack from '@mui/material/Stack';
+import IconButton from '@mui/material/IconButton';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import PauseIcon from '@mui/icons-material/Pause';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import Typography from '@mui/material/Typography';
+import Slider from '@mui/material/Slider';
+import { useState } from 'react';
+
+interface TransportBarProps {
+  onPlay: () => void;
+  onPause: () => void;
+  onRecord: () => void;
+}
+
+export const TransportBar = ({ onPlay, onPause, onRecord }: TransportBarProps) => {
+  const [tempo, setTempo] = useState(120);
+  const [volume, setVolume] = useState(0.8);
+
+  return (
+    <Stack direction="row" spacing={2} alignItems="center" p={1}>
+      <IconButton aria-label="record" onClick={onRecord} color="error">
+        <FiberManualRecordIcon />
+      </IconButton>
+      <IconButton aria-label="play" onClick={onPlay} color="primary">
+        <PlayArrowIcon />
+      </IconButton>
+      <IconButton aria-label="pause" onClick={onPause} color="primary">
+        <PauseIcon />
+      </IconButton>
+      <Typography>Tempo</Typography>
+      <Slider value={tempo} onChange={(_, v) => setTempo(v as number)} min={60} max={200} sx={{ width: 100 }} />
+      <Typography>Volume</Typography>
+      <Slider value={volume} onChange={(_, v) => setVolume(v as number)} min={0} max={1} step={0.01} sx={{ width: 100 }} />
+    </Stack>
+  );
+};

--- a/frontend/src/components/WaveformViewer.tsx
+++ b/frontend/src/components/WaveformViewer.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import Box from '@mui/material/Box';
+
+export interface WaveformViewerProps {
+  audioBuffer?: AudioBuffer;
+  markers?: Array<{ time: number; label?: string }>;
+}
+
+export const WaveformViewer = ({ audioBuffer, markers = [] }: WaveformViewerProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!canvasRef.current || !audioBuffer) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const { width, height } = canvas;
+    ctx.clearRect(0, 0, width, height);
+    // simple waveform render
+    const data = audioBuffer.getChannelData(0);
+    ctx.beginPath();
+    for (let x = 0; x < width; x++) {
+      const i = Math.floor((x / width) * data.length);
+      const y = (0.5 + data[i] / 2) * height;
+      ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = 'cyan';
+    ctx.stroke();
+    markers.forEach(m => {
+      const x = (m.time / audioBuffer.duration) * width;
+      ctx.fillStyle = 'yellow';
+      ctx.fillRect(x, 0, 2, height);
+    });
+  }, [audioBuffer, markers]);
+
+  return <Box sx={{ p: 1 }}><canvas ref={canvasRef} width={400} height={80} /></Box>;
+};

--- a/frontend/src/hooks/useAudioContext.ts
+++ b/frontend/src/hooks/useAudioContext.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+import * as Tone from 'tone';
+
+export function useAudioContext() {
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (!started.current) {
+      Tone.start();
+      started.current = true;
+    }
+  }, []);
+
+  return Tone.getContext();
+}

--- a/frontend/src/hooks/useChordStream.ts
+++ b/frontend/src/hooks/useChordStream.ts
@@ -1,0 +1,16 @@
+import { useState, useCallback } from 'react';
+
+export interface ChordEvent {
+  time: number;
+  chord: string;
+}
+
+export function useChordStream(initial: ChordEvent[] = []) {
+  const [events, setEvents] = useState<ChordEvent[]>(initial);
+
+  const addEvent = useCallback((evt: ChordEvent) => {
+    setEvents((prev) => [...prev, evt].sort((a, b) => a.time - b.time));
+  }, []);
+
+  return { events, addEvent };
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- add `frontend` React app using Vite + TypeScript
- implement waveform, chord timeline, accompaniment panel and transport bar components
- setup Jest + Testing Library with a sample test
- document usage in `frontend/README.md`

## Testing
- `pytest -q`
- `npm test --prefix frontend -- -u`

------
https://chatgpt.com/codex/tasks/task_e_684dca9b27a0833191167d7b7d71018a