### PR TITLE
Add real-time chord websocket streaming

### DIFF
--- a/frontend/src/__tests__/ChordStream.test.tsx
+++ b/frontend/src/__tests__/ChordStream.test.tsx
@@ -1,0 +1,41 @@
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useChordStream } from '../hooks/useChordStream';
+import { ChordTimeline } from '../components/ChordTimeline';
+
+jest.mock('react-dnd', () => ({
+  useDrag: () => [{}, () => {}],
+  useDrop: () => [{}, () => {}]
+}));
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(url: string) {
+    MockWebSocket.instances.push(this);
+  }
+  close() {
+    this.onclose && this.onclose();
+  }
+  sendMessage(msg: any) {
+    this.onmessage && this.onmessage({ data: JSON.stringify(msg) });
+  }
+}
+
+(global as any).WebSocket = MockWebSocket as any;
+
+const Wrapper = () => {
+  const { events } = useChordStream();
+  return <ChordTimeline events={events} onMove={() => {}} />;
+};
+
+test('timeline updates on chord websocket message', async () => {
+  const { findByText } = render(<Wrapper />);
+  const ws = MockWebSocket.instances[0];
+  act(() => {
+    ws.sendMessage({ time: 1, chord: 'C' });
+  });
+  expect(await findByText('C')).toBeInTheDocument();
+});

--- a/frontend/src/components/ChordTimeline.tsx
+++ b/frontend/src/components/ChordTimeline.tsx
@@ -13,8 +13,8 @@ export interface ChordTimelineProps {
 export const ChordTimeline = ({ events, onMove }: ChordTimelineProps) => {
   const [, drop] = useDrop({ accept: 'CHORD' });
 
-  const Row = ({ index, style }: { index: number; style: CSSProperties }) => {
-    const evt = events[index];
+  const Row = ({ index, style, data }: { index: number; style: CSSProperties; data: ChordEvent[] }) => {
+    const evt = data[index];
     return (
       <ChordBlock
         style={style}
@@ -33,6 +33,7 @@ export const ChordTimeline = ({ events, onMove }: ChordTimelineProps) => {
         width={800}
         itemCount={events.length}
         itemSize={90}
+        itemData={events}
         layout="horizontal"
         overscanCount={5}
         style={{ overflowX: 'auto' }}

--- a/frontend/src/hooks/useChordStream.ts
+++ b/frontend/src/hooks/useChordStream.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 export interface ChordEvent {
   time: number;
@@ -7,10 +7,44 @@ export interface ChordEvent {
 
 export function useChordStream(initial: ChordEvent[] = []) {
   const [events, setEvents] = useState<ChordEvent[]>(initial);
+  const [ws, setWs] = useState<WebSocket>();
 
   const addEvent = useCallback((evt: ChordEvent) => {
     setEvents((prev) => [...prev, evt].sort((a, b) => a.time - b.time));
   }, []);
+
+  useEffect(() => {
+    let socket: WebSocket | undefined;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const connect = () => {
+      socket = new WebSocket('ws://localhost:8000/ws');
+      setWs(socket);
+      socket.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data);
+          if (typeof data.time === 'number' && typeof data.chord === 'string') {
+            addEvent({ time: data.time, chord: data.chord });
+          }
+        } catch (err) {
+          console.error('bad message', err);
+        }
+      };
+      socket.onclose = () => {
+        timer = setTimeout(connect, 1000);
+      };
+      socket.onerror = () => {
+        socket?.close();
+      };
+    };
+
+    connect();
+
+    return () => {
+      clearTimeout(timer);
+      socket?.close();
+    };
+  }, [addEvent]);
 
   return { events, addEvent };
 }


### PR DESCRIPTION
## Summary
- connect to backend WebSocket in `useChordStream`
- ensure timeline list re-renders using `itemData`
- test chord streaming via mocked WebSocket

## Testing
- `pytest -q`
- `cd frontend && npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_684dd27d79b08331a01dab37fddb4454