### PR TITLE
Add keyboard transport controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ export const App = () => {
           onRecord={() => {}}
           onToggleTheme={() => setDark(!dark)}
           dark={dark}
+          bindKeys
         />
       </Box>
     </ThemeProvider>

--- a/frontend/src/__tests__/TransportBar.test.tsx
+++ b/frontend/src/__tests__/TransportBar.test.tsx
@@ -1,5 +1,6 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 jest.mock('../hooks/useMidiOutput', () => ({ useMidiOutput: () => ({ playNote: jest.fn() }) }));
+jest.mock('tone', () => ({ Transport: { state: 'stopped', seconds: 0 } }));
 import { TransportBar } from '../components/TransportBar';
 import '@testing-library/jest-dom';
 
@@ -10,4 +11,31 @@ test('theme toggle switch calls handler', () => {
   );
   fireEvent.click(getByRole('checkbox'));
   expect(handler).toHaveBeenCalled();
+});
+
+test('space toggles play and pause', async () => {
+  const onPlay = jest.fn();
+  const onPause = jest.fn();
+  const { Transport } = await import('tone');
+  (Transport as any).state = 'stopped';
+  render(
+    <TransportBar onPlay={onPlay} onPause={onPause} onRecord={() => {}} onToggleTheme={() => {}} dark={false} bindKeys />
+  );
+  fireEvent.keyDown(window, { code: 'Space' });
+  await waitFor(() => expect(onPlay).toHaveBeenCalled());
+  (Transport as any).state = 'started';
+  fireEvent.keyDown(window, { code: 'Space' });
+  await waitFor(() => expect(onPause).toHaveBeenCalled());
+});
+
+test('arrow keys step transport time', async () => {
+  const { Transport } = await import('tone');
+  (Transport as any).seconds = 0;
+  render(
+    <TransportBar onPlay={() => {}} onPause={() => {}} onRecord={() => {}} onToggleTheme={() => {}} dark={false} bindKeys />
+  );
+  fireEvent.keyDown(window, { code: 'ArrowRight' });
+  await waitFor(() => expect((Transport as any).seconds).toBe(1));
+  fireEvent.keyDown(window, { code: 'ArrowLeft' });
+  await waitFor(() => expect((Transport as any).seconds).toBe(0));
 });

--- a/frontend/src/components/TransportBar.tsx
+++ b/frontend/src/components/TransportBar.tsx
@@ -5,7 +5,7 @@ import PauseIcon from '@mui/icons-material/Pause';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import Typography from '@mui/material/Typography';
 import Slider from '@mui/material/Slider';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Switch from '@mui/material/Switch';
 import { useMidiOutput } from '../hooks/useMidiOutput';
 
@@ -15,12 +15,36 @@ interface TransportBarProps {
   onRecord: () => void;
   onToggleTheme: () => void;
   dark: boolean;
+  bindKeys?: boolean;
 }
 
-export const TransportBar = ({ onPlay, onPause, onRecord, onToggleTheme, dark }: TransportBarProps) => {
+export const TransportBar = ({ onPlay, onPause, onRecord, onToggleTheme, dark, bindKeys }: TransportBarProps) => {
   const [tempo, setTempo] = useState(120);
   const [volume, setVolume] = useState(0.8);
   const { playNote } = useMidiOutput();
+
+  useEffect(() => {
+    if (!bindKeys) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        e.preventDefault();
+        import('tone').then(Tone => {
+          if (Tone.Transport.state === 'started') {
+            onPause();
+          } else {
+            onPlay();
+          }
+        });
+      } else if (e.code === 'ArrowRight' || e.code === 'ArrowLeft') {
+        import('tone').then(Tone => {
+          const delta = e.code === 'ArrowRight' ? 1 : -1;
+          Tone.Transport.seconds = Math.max(0, Tone.Transport.seconds + delta);
+        });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [bindKeys, onPlay, onPause]);
 
   return (
     <Stack direction="row" spacing={2} alignItems="center" p={1}>


### PR DESCRIPTION
## Summary
- add optional `bindKeys` prop for TransportBar and handle global key events
- hook `bindKeys` from App
- test keyboard shortcuts in `TransportBar`

## Testing
- `npm test -- --runTestsByPath src/__tests__/TransportBar.test.tsx`
- `npm test -- --runTestsByPath src/__tests__/WaveformViewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_684dd27f9ac48331b024c54279b1313a