### PR TITLE
Add frontend npm tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt -r requirements-dev.txt
+          npm ci --prefix frontend
       - name: Lint
         run: flake8
       - name: Type check
@@ -27,6 +34,9 @@ jobs:
         run: bandit -r src || true
       - name: Test
         run: pytest -vv
+      - name: Frontend tests
+        run: npm test
+        working-directory: frontend
       - name: Build Docker
         run: docker build -t music-api:latest .
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,22 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - run: pip install -r requirements.txt -r requirements-dev.txt
+      - run: npm ci
+        working-directory: frontend
       - run: pytest -vv
+      - run: npm test
+        working-directory: frontend


### PR DESCRIPTION
## Summary
- setup Node in CI workflows
- run `npm ci` inside `frontend`
- execute `npm test` for frontend

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd286b80883319c000ed5912b4eb2