### PR TITLE
Add songwriting instructions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ FastAPI with Ray Serve for scalable inference.
 - `audio_streaming` – audio utilities & streaming
 - `feature_extraction` – feature engineering
 - `llm` – chord suggestion model
+- `instructions` – songwriting steps generator
+- `tabs` – guitar and bass tab generation
 - `filter` – signal processing
 - `accompaniment` – accompaniment generation
 - `api` – FastAPI service
@@ -26,6 +28,15 @@ bytes. The server responds with `{"ack": true}` for each chunk and streams back
 chord predictions using messages like `{"chords": ["C", "G", "Am", "F"]}` as soon
 as they become available. A heartbeat message `{"type": "ping"}` is also sent
 periodically.
+
+## Songwriting Instructions
+Musicians without formal theory knowledge can call the `/instructions` endpoint
+with a theme to receive step-by-step guidance for composing a simple song.
+
+## Guitar & Bass Tabs
+Send a list of chords to `/tabs` to receive simple guitar and bass tabs that
+match the progression. This helps players quickly accompany their ideas without
+deep theory knowledge.
 
 ## References
 - MLOps & CI/CD alignment inspired by [Practical MLOps](https://github.com/ai-understanding/practical-mlops)

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,0 +1,7 @@
+"""LLM utilities for music generation."""
+
+from .chord_suggester import ChordSuggester
+from .instruction_generator import InstructionGenerator
+from .tab_generator import TabGenerator
+
+__all__ = ["ChordSuggester", "InstructionGenerator", "TabGenerator"]

--- a/src/llm/instruction_generator.py
+++ b/src/llm/instruction_generator.py
@@ -1,0 +1,19 @@
+"""Songwriting instruction generator."""
+
+from typing import List
+
+
+class InstructionGenerator:
+    """Generate simple songwriting instructions."""
+
+    version = "v1"
+
+    def generate(self, theme: str) -> List[str]:
+        """Return a basic set of songwriting steps."""
+        return [
+            f"Start with the theme '{theme}'.",
+            "Create a four-chord progression (e.g. C - G - Am - F).",
+            "Write a short verse exploring the theme.",
+            "Develop a chorus that contrasts the verse.",
+            "Layer instrumentation and refine your arrangement.",
+        ]

--- a/src/llm/tab_generator.py
+++ b/src/llm/tab_generator.py
@@ -1,0 +1,82 @@
+"""Simple guitar and bass tab generator."""
+
+from typing import Dict, List
+
+
+class TabGenerator:
+    """Generate basic tabs for a chord progression."""
+
+    version = "v1"
+
+    GUITAR_MAP = {
+        "C": [
+            "e|-0-",
+            "B|-1-",
+            "G|-0-",
+            "D|-2-",
+            "A|-3-",
+            "E|---",
+        ],
+        "G": [
+            "e|-3-",
+            "B|-0-",
+            "G|-0-",
+            "D|-0-",
+            "A|-2-",
+            "E|-3-",
+        ],
+        "Am": [
+            "e|-0-",
+            "B|-1-",
+            "G|-2-",
+            "D|-2-",
+            "A|-0-",
+            "E|---",
+        ],
+        "F": [
+            "e|-1-",
+            "B|-1-",
+            "G|-2-",
+            "D|-3-",
+            "A|-3-",
+            "E|-1-",
+        ],
+    }
+
+    BASS_MAP = {
+        "C": [
+            "G|----",
+            "D|----",
+            "A|-3--",
+            "E|----",
+        ],
+        "G": [
+            "G|----",
+            "D|----",
+            "A|----",
+            "E|-3--",
+        ],
+        "Am": [
+            "G|---",
+            "D|---",
+            "A|-0-",
+            "E|---",
+        ],
+        "F": [
+            "G|---",
+            "D|---",
+            "A|---",
+            "E|-1-",
+        ],
+    }
+
+    def generate(self, chords: List[str]) -> Dict[str, List[str]]:
+        """Return simple guitar and bass tabs."""
+        guitar: List[str] = []
+        bass: List[str] = []
+        for chord in chords:
+            g_lines = self.GUITAR_MAP.get(chord, [f"# {chord}"])
+            b_lines = self.BASS_MAP.get(chord, [f"# {chord}"])
+            guitar.extend(g_lines + [""])
+            bass.extend(b_lines + [""])
+        return {"guitar": guitar, "bass": bass}

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -1,0 +1,18 @@
+from src.llm.instruction_generator import InstructionGenerator
+from src.api.main import app
+from fastapi.testclient import TestClient
+
+
+def test_generate_instructions():
+    steps = InstructionGenerator().generate("love")
+    assert steps
+    assert "love" in steps[0].lower()
+
+
+def test_instructions_endpoint():
+    with TestClient(app) as client:
+        resp = client.post("/instructions", json={"theme": "love"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "steps" in data
+        assert any("love" in step.lower() for step in data["steps"])

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,0 +1,17 @@
+from src.llm.tab_generator import TabGenerator
+from src.api.main import app
+from fastapi.testclient import TestClient
+
+
+def test_generate_tabs():
+    tabs = TabGenerator().generate(["C", "G"])
+    assert "guitar" in tabs and "bass" in tabs
+    assert len(tabs["guitar"]) > 0 and len(tabs["bass"]) > 0
+
+
+def test_tabs_endpoint():
+    with TestClient(app) as client:
+        resp = client.post("/tabs", json={"chords": ["C", "G"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "guitar" in data and "bass" in data


### PR DESCRIPTION
## Summary
- expand `llm` package with `InstructionGenerator`
- expose `/instructions` endpoint in API for songwriting steps
- document new module in README
- export new generator from `llm` init
- add tests for instruction generation
- extend instructions with guitar and bass tab generation

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd569d32c833196a9000cc6a5820d