### PR TITLE
Add ClockworkRed Android scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Kotlin/Android build outputs
+**/build/
+**/local.properties
+/.gradle/
+**/__pycache__/

--- a/ClockworkRed/app/build.gradle.kts
+++ b/ClockworkRed/app/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.dagger.hilt.android")
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.clockworkred.app"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.clockworkred.app"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":domain"))
+    implementation(project(":data"))
+
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    implementation("androidx.compose.ui:ui:1.5.0")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.5.0")
+    implementation("androidx.compose.material3:material3:1.1.1")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.5.0")
+
+    implementation("com.google.dagger:hilt-android:2.48")
+    kapt("com.google.dagger:hilt-android-compiler:2.48")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/ClockworkRed/app/src/main/AndroidManifest.xml
+++ b/ClockworkRed/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.clockworkred.app">
+
+    <application
+        android:name="com.clockworkred.app.ClockworkRedApp"
+        android:label="ClockworkRed"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name="com.clockworkred.app.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/AppNavGraph.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/AppNavGraph.kt
@@ -1,0 +1,14 @@
+package com.clockworkred.app
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+
+@Composable
+fun AppNavGraph(navController: NavHostController) {
+    NavHost(navController = navController, startDestination = "splash") {
+        composable("splash") { SplashScreen(navController) }
+        composable("home") { HomeScreen(navController) }
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ClockworkRedApp.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ClockworkRedApp.kt
@@ -1,0 +1,7 @@
+package com.clockworkred.app
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class ClockworkRedApp : Application()

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/EditorScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/EditorScreen.kt
@@ -1,0 +1,14 @@
+package com.clockworkred.app
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun EditorScreen(viewModel: EditorViewModel = hiltViewModel()) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        // TODO: collaborative tab editing canvas
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/EditorViewModel.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/EditorViewModel.kt
@@ -1,0 +1,8 @@
+package com.clockworkred.app
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class EditorViewModel @Inject constructor() : ViewModel()

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
@@ -1,0 +1,15 @@
+package com.clockworkred.app
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+
+@Composable
+fun HomeNavGraph(navController: NavHostController) {
+    NavHost(navController = navController, startDestination = "projects") {
+        composable("projects") { ProjectsScreen() }
+        composable("editor") { EditorScreen() }
+        composable("settings") { SettingsScreen() }
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeScreen.kt
@@ -1,0 +1,62 @@
+package com.clockworkred.app
+
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(navController: NavHostController) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    Scaffold(
+        bottomBar = {
+            BottomAppBar {
+                NavigationBarItem(
+                    selected = currentRoute == "projects",
+                    onClick = {
+                        navController.navigate("projects") {
+                            popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    icon = { Text("Projects") }
+                )
+                NavigationBarItem(
+                    selected = currentRoute == "editor",
+                    onClick = {
+                        navController.navigate("editor") {
+                            popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    icon = { Text("Editor") }
+                )
+                NavigationBarItem(
+                    selected = currentRoute == "settings",
+                    onClick = {
+                        navController.navigate("settings") {
+                            popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    icon = { Text("Settings") }
+                )
+            }
+        }
+    ) { innerPadding ->
+        HomeNavGraph(navController)
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/MainActivity.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/MainActivity.kt
@@ -1,0 +1,24 @@
+package com.clockworkred.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.navigation.compose.rememberNavController
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ClockworkRedAppTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    val navController = rememberNavController()
+                    AppNavGraph(navController)
+                }
+            }
+        }
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ProjectsScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ProjectsScreen.kt
@@ -1,0 +1,16 @@
+package com.clockworkred.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun ProjectsScreen(viewModel: ProjectsViewModel = hiltViewModel()) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "Projects - empty")
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ProjectsViewModel.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ProjectsViewModel.kt
@@ -1,0 +1,8 @@
+package com.clockworkred.app
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProjectsViewModel @Inject constructor() : ViewModel()

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/SettingsScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/SettingsScreen.kt
@@ -1,0 +1,31 @@
+package com.clockworkred.app
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
+    val apiKey by viewModel.apiKey.collectAsState("")
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = apiKey,
+            onValueChange = { viewModel.saveApiKey(it) },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("API Key") }
+        )
+        Button(onClick = { viewModel.saveApiKey(apiKey) }, modifier = Modifier.padding(top = 8.dp)) {
+            Text("Save")
+        }
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/SettingsViewModel.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/SettingsViewModel.kt
@@ -1,0 +1,21 @@
+package com.clockworkred.app
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clockworkred.domain.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val repository: SettingsRepository
+) : ViewModel() {
+    val apiKey = repository.apiKey.stateIn(viewModelScope, SharingStarted.Lazily, "")
+
+    fun saveApiKey(key: String) {
+        viewModelScope.launch { repository.saveApiKey(key) }
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/SplashScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/SplashScreen.kt
@@ -1,0 +1,24 @@
+package com.clockworkred.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.delay
+
+@Composable
+fun SplashScreen(navController: NavHostController) {
+    LaunchedEffect(Unit) {
+        delay(1000)
+        navController.navigate("home") {
+            popUpTo("splash") { inclusive = true }
+        }
+    }
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("ClockworkRed")
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/Theme.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/Theme.kt
@@ -1,0 +1,17 @@
+package com.clockworkred.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.core.view.WindowCompat
+
+@Composable
+fun ClockworkRedAppTheme(content: @Composable () -> Unit) {
+    val colors = lightColorScheme()
+    MaterialTheme(
+        colorScheme = colors,
+        content = content
+    )
+}

--- a/ClockworkRed/app/src/main/res/values/themes.xml
+++ b/ClockworkRed/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ClockworkRed" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+</resources>

--- a/ClockworkRed/app/src/test/java/com/clockworkred/app/SettingsViewModelTest.kt
+++ b/ClockworkRed/app/src/test/java/com/clockworkred/app/SettingsViewModelTest.kt
@@ -1,0 +1,35 @@
+package com.clockworkred.app
+
+import com.clockworkred.domain.SettingsRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class FakeSettingsRepository : SettingsRepository {
+    private val _key = MutableStateFlow("")
+    override val apiKey = _key
+    override suspend fun saveApiKey(key: String) {
+        _key.value = key
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+    private lateinit var viewModel: SettingsViewModel
+    private lateinit var repo: FakeSettingsRepository
+
+    @Before
+    fun setup() {
+        repo = FakeSettingsRepository()
+        viewModel = SettingsViewModel(repo)
+    }
+
+    @Test
+    fun saveApiKey_updatesFlow() = runTest {
+        viewModel.saveApiKey("123")
+        assertEquals("123", repo.apiKey.value)
+    }
+}

--- a/ClockworkRed/build.gradle.kts
+++ b/ClockworkRed/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("com.android.application") version "8.1.1" apply false
+    id("com.android.library") version "8.1.1" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+    id("com.google.dagger.hilt.android") version "2.48" apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/ClockworkRed/data/build.gradle.kts
+++ b/ClockworkRed/data/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("com.google.dagger.hilt.android")
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.clockworkred.data"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+    }
+}
+
+dependencies {
+    implementation(project(":domain"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+
+    implementation("com.google.dagger:hilt-android:2.48")
+    kapt("com.google.dagger:hilt-android-compiler:2.48")
+}

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/AiService.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/AiService.kt
@@ -1,0 +1,8 @@
+package com.clockworkred.data
+
+import retrofit2.http.GET
+
+interface AiService {
+    @GET("/todo")
+    suspend fun placeholder()
+}

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/DataModule.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/DataModule.kt
@@ -1,0 +1,29 @@
+package com.clockworkred.data
+
+import com.clockworkred.domain.SettingsRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataModule {
+    @Binds
+    @Singleton
+    abstract fun bindSettingsRepository(impl: SettingsRepositoryImpl): SettingsRepository
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideAiService(): AiService {
+            return Retrofit.Builder()
+                .baseUrl("https://example.com")
+                .build()
+                .create(AiService::class.java)
+        }
+    }
+}

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/SettingsRepositoryImpl.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/SettingsRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.clockworkred.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.clockworkred.domain.SettingsRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.dataStore by preferencesDataStore("settings")
+
+@Singleton
+class SettingsRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : SettingsRepository {
+    private val KEY_API = stringPreferencesKey("api_key")
+
+    override val apiKey: Flow<String> = context.dataStore.data.map { it[KEY_API] ?: "" }
+
+    override suspend fun saveApiKey(key: String) {
+        context.dataStore.edit { it[KEY_API] = key }
+    }
+}

--- a/ClockworkRed/domain/build.gradle.kts
+++ b/ClockworkRed/domain/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.clockworkred.domain"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+    }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/SettingsRepository.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/SettingsRepository.kt
@@ -1,0 +1,8 @@
+package com.clockworkred.domain
+
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+    val apiKey: Flow<String>
+    suspend fun saveApiKey(key: String)
+}

--- a/ClockworkRed/gradle.properties
+++ b/ClockworkRed/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true
+kotlin.code.style=official

--- a/ClockworkRed/settings.gradle.kts
+++ b/ClockworkRed/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "ClockworkRed"
+include(":app", ":data", ":domain")

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ FastAPI for scalable inference.
 - `filter` – signal processing
 - `accompaniment` – accompaniment generation
 - `api` – FastAPI service
+- `ClockworkRed` – Android client
 - `utils` – helpers (cache, connection manager)
 - `deployment` – Docker Compose and Kubernetes examples
 
@@ -43,3 +44,5 @@ deep theory knowledge.
 - Twelve-Factor app containerization best practices
 - FastAPI deployment workflow: [FastAPI docs on Docker](https://fastapi.tiangolo.com/deployment/docker/)
 - Model monitoring & versioning guidelines: [MLOps with monitoring](https://madewithml.com/courses/mlops/monitoring/)
+
+For mobile development, see the `ClockworkRed` directory for an Android client built with Kotlin and Jetpack Compose.


### PR DESCRIPTION
## Summary
- scaffold ClockworkRed Android project
- implement app, data, and domain modules with Hilt DI
- add Compose navigation and screens (Projects, Editor, Settings)
- save API key using DataStore
- add Retrofit and coroutine stubs
- update README with new module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6853e771a6b08331a1f1f4fc3bd52b42