### PR TITLE
Implement arrangement canvas and export screens

### DIFF
--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/AppModule.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/AppModule.kt
@@ -1,0 +1,18 @@
+package com.clockworkred.app
+
+import com.clockworkred.data.repository.FakeArrangementRepository
+import com.clockworkred.domain.ArrangementRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** Hilt bindings for app-level dependencies. */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AppModule {
+    @Binds
+    @Singleton
+    abstract fun bindArrangementRepository(impl: FakeArrangementRepository): ArrangementRepository
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
@@ -6,6 +6,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.clockworkred.app.ui.projects.ProjectsScreen
 import com.clockworkred.app.ui.editor.TabEditorScreen
+import com.clockworkred.app.ui.arrangement.ArrangementCanvasScreen
+import com.clockworkred.app.ui.export.ExportScreen
 import com.clockworkred.app.SettingsScreen
 import com.clockworkred.app.editor.TabEditorViewModel
 import com.clockworkred.domain.model.Instrument
@@ -28,5 +30,7 @@ fun HomeNavGraph(navController: NavHostController) {
             TabEditorScreen(viewModel)
         }
         composable("settings") { SettingsScreen() }
+        composable("arrangement") { ArrangementCanvasScreen(navController) }
+        composable("export") { ExportScreen() }
     }
 }

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/arrangement/ArrangementViewModel.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/arrangement/ArrangementViewModel.kt
@@ -1,0 +1,69 @@
+package com.clockworkred.app.arrangement
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clockworkred.domain.model.ArrangementStructure
+import com.clockworkred.domain.usecase.GetArrangementStructureUseCase
+import com.clockworkred.domain.usecase.SaveArrangementUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** ViewModel for the arrangement canvas screen. */
+@HiltViewModel
+class ArrangementViewModel @Inject constructor(
+    private val getArrangement: GetArrangementStructureUseCase,
+    private val saveArrangementUseCase: SaveArrangementUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ArrangementUiState())
+    val uiState: StateFlow<ArrangementUiState> = _uiState
+
+    init {
+        viewModelScope.launch {
+            getArrangement()
+                .onStart { _uiState.value = _uiState.value.copy(isSaving = false, error = null) }
+                .catch { _uiState.value = ArrangementUiState(error = it.message) }
+                .collect { structure ->
+                    _uiState.value = ArrangementUiState(structure = structure)
+                }
+        }
+    }
+
+    fun moveSection(from: Int, to: Int) {
+        val sections = _uiState.value.structure.sections.toMutableList()
+        if (from in sections.indices && to in sections.indices) {
+            val item = sections.removeAt(from)
+            sections.add(to, item)
+            _uiState.value = _uiState.value.copy(
+                structure = _uiState.value.structure.copy(
+                    sections = sections.mapIndexed { index, s -> s.copy(position = index) }
+                )
+            )
+        }
+    }
+
+    fun saveArrangement() {
+        val structure = _uiState.value.structure
+        viewModelScope.launch {
+            try {
+                _uiState.value = _uiState.value.copy(isSaving = true)
+                saveArrangementUseCase(structure)
+                _uiState.value = _uiState.value.copy(isSaving = false)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(isSaving = false, error = e.message)
+            }
+        }
+    }
+}
+
+/** UI state for [ArrangementCanvasScreen]. */
+data class ArrangementUiState(
+    val structure: ArrangementStructure = ArrangementStructure(emptyList()),
+    val isSaving: Boolean = false,
+    val error: String? = null
+)

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/arrangement/ArrangementCanvasScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/arrangement/ArrangementCanvasScreen.kt
@@ -1,0 +1,72 @@
+package com.clockworkred.app.ui.arrangement
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.clockworkred.app.arrangement.ArrangementViewModel
+import com.clockworkred.domain.model.SongSectionOrder
+
+@Composable
+fun ArrangementCanvasScreen(
+    navController: NavHostController,
+    viewModel: ArrangementViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                itemsIndexed(uiState.structure.sections, key = { _, item -> item.section.name }) { index, item: SongSectionOrder ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Icon(Icons.Default.DragHandle, contentDescription = "Drag")
+                        // TODO implement real drag and drop reordering
+                        Text(
+                            text = item.section.name.lowercase().replaceFirstChar { it.uppercaseChar() },
+                            modifier = Modifier.weight(1f).padding(start = 8.dp)
+                        )
+                        IconButton(onClick = { viewModel.moveSection(index, index - 1) }) {
+                            Icon(Icons.Default.ArrowUpward, contentDescription = "Move Up")
+                        }
+                        IconButton(onClick = { viewModel.moveSection(index, index + 1) }) {
+                            Icon(Icons.Default.ArrowDownward, contentDescription = "Move Down")
+                        }
+                    }
+                }
+            }
+            Button(
+                onClick = { viewModel.saveArrangement() },
+                modifier = Modifier.fillMaxWidth().padding(16.dp)
+            ) {
+                Text("Save Arrangement")
+            }
+        }
+        if (uiState.isSaving) {
+            Box(modifier = Modifier.matchParentSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        FloatingActionButton(
+            onClick = { navController.navigate("export") },
+            modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)
+        ) {
+            Icon(Icons.Default.Share, contentDescription = "Export")
+        }
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/export/ExportScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/export/ExportScreen.kt
@@ -1,0 +1,27 @@
+package com.clockworkred.app.ui.export
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/** Screen offering export options for an arrangement. */
+@Composable
+fun ExportScreen() {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Button(onClick = { /* TODO generate and save PDF to storage */ }, modifier = Modifier.fillMaxWidth()) {
+            Text("Download PDF")
+        }
+        Button(onClick = { /* TODO share generated PDF */ }, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+            Text("Share PDF")
+        }
+        Button(onClick = { /* TODO export MIDI file */ }, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+            Text("Export MIDI")
+        }
+        // TODO request WRITE_EXTERNAL_STORAGE permission when implementing file operations
+    }
+}

--- a/ClockworkRed/app/src/test/java/com/clockworkred/app/arrangement/ArrangementViewModelTest.kt
+++ b/ClockworkRed/app/src/test/java/com/clockworkred/app/arrangement/ArrangementViewModelTest.kt
@@ -1,0 +1,67 @@
+package com.clockworkred.app.arrangement
+
+import com.clockworkred.domain.ArrangementRepository
+import com.clockworkred.domain.model.ArrangementStructure
+import com.clockworkred.domain.model.SongSection
+import com.clockworkred.domain.model.SongSectionOrder
+import com.clockworkred.domain.usecase.GetArrangementStructureUseCase
+import com.clockworkred.domain.usecase.SaveArrangementUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+private class FakeArrangementRepository : ArrangementRepository {
+    val flow = MutableStateFlow(
+        ArrangementStructure(
+            listOf(
+                SongSectionOrder(SongSection.INTRO, 0),
+                SongSectionOrder(SongSection.VERSE, 1)
+            )
+        )
+    )
+
+    override fun getArrangement(): Flow<ArrangementStructure> = flow.asStateFlow()
+    override suspend fun saveArrangement(structure: ArrangementStructure) { flow.value = structure }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArrangementViewModelTest {
+    private lateinit var viewModel: ArrangementViewModel
+    private lateinit var repo: FakeArrangementRepository
+
+    @Before
+    fun setup() {
+        repo = FakeArrangementRepository()
+        val getUseCase = GetArrangementStructureUseCase(repo)
+        val saveUseCase = SaveArrangementUseCase(repo)
+        viewModel = ArrangementViewModel(getUseCase, saveUseCase)
+    }
+
+    @Test
+    fun initialState_loadsDefaultArrangement() = runTest {
+        advanceUntilIdle()
+        assertEquals(2, viewModel.uiState.value.structure.sections.size)
+    }
+
+    @Test
+    fun moveSection_updatesOrder() = runTest {
+        advanceUntilIdle()
+        viewModel.moveSection(0, 1)
+        val second = viewModel.uiState.value.structure.sections[1]
+        assertEquals(SongSection.INTRO, second.section)
+    }
+
+    @Test
+    fun saveArrangement_togglesFlag() = runTest {
+        advanceUntilIdle()
+        viewModel.saveArrangement()
+        assertFalse(viewModel.uiState.value.isSaving)
+    }
+}

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/ArrangementEntity.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/ArrangementEntity.kt
@@ -1,0 +1,13 @@
+package com.clockworkred.data.repository
+
+import com.clockworkred.domain.model.SongSection
+
+/** Data entity mirroring [ArrangementStructure]. */
+data class ArrangementEntity(
+    val sections: List<SongSectionOrderEntity>
+)
+
+data class SongSectionOrderEntity(
+    val section: SongSection,
+    val position: Int
+)

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/FakeArrangementRepository.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/FakeArrangementRepository.kt
@@ -1,0 +1,34 @@
+package com.clockworkred.data.repository
+
+import com.clockworkred.domain.ArrangementRepository
+import com.clockworkred.domain.model.ArrangementStructure
+import com.clockworkred.domain.model.SongSection
+import com.clockworkred.domain.model.SongSectionOrder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Fake implementation of [ArrangementRepository] for testing. */
+@Singleton
+class FakeArrangementRepository @Inject constructor() : ArrangementRepository {
+    private val defaultStructure = ArrangementStructure(
+        sections = listOf(
+            SongSectionOrder(SongSection.INTRO, 0),
+            SongSectionOrder(SongSection.VERSE, 1),
+            SongSectionOrder(SongSection.CHORUS, 2),
+            SongSectionOrder(SongSection.BRIDGE, 3),
+            SongSectionOrder(SongSection.OUTRO, 4)
+        )
+    )
+
+    private val structureFlow = MutableStateFlow(defaultStructure)
+
+    override fun getArrangement(): Flow<ArrangementStructure> = structureFlow.asStateFlow()
+
+    override suspend fun saveArrangement(structure: ArrangementStructure) {
+        structureFlow.value = structure
+        // no-op persistence for fake
+    }
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/ArrangementRepository.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/ArrangementRepository.kt
@@ -1,0 +1,10 @@
+package com.clockworkred.domain
+
+import com.clockworkred.domain.model.ArrangementStructure
+import kotlinx.coroutines.flow.Flow
+
+/** Repository for accessing and saving arrangement data. */
+interface ArrangementRepository {
+    fun getArrangement(): Flow<ArrangementStructure>
+    suspend fun saveArrangement(structure: ArrangementStructure)
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/model/ArrangementStructure.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/model/ArrangementStructure.kt
@@ -1,0 +1,12 @@
+package com.clockworkred.domain.model
+
+/** Represents the ordered sections of a song arrangement. */
+data class ArrangementStructure(
+    val sections: List<SongSectionOrder>
+)
+
+/** Pairing of a [SongSection] with its position in the arrangement. */
+data class SongSectionOrder(
+    val section: SongSection,
+    val position: Int
+)

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/GetArrangementStructureUseCase.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/GetArrangementStructureUseCase.kt
@@ -1,0 +1,13 @@
+package com.clockworkred.domain.usecase
+
+import com.clockworkred.domain.ArrangementRepository
+import com.clockworkred.domain.model.ArrangementStructure
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/** Use case to retrieve the current arrangement structure. */
+class GetArrangementStructureUseCase @Inject constructor(
+    private val repository: ArrangementRepository
+) {
+    operator fun invoke(): Flow<ArrangementStructure> = repository.getArrangement()
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/SaveArrangementUseCase.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/SaveArrangementUseCase.kt
@@ -1,0 +1,14 @@
+package com.clockworkred.domain.usecase
+
+import com.clockworkred.domain.ArrangementRepository
+import com.clockworkred.domain.model.ArrangementStructure
+import javax.inject.Inject
+
+/** Persists an [ArrangementStructure]. */
+class SaveArrangementUseCase @Inject constructor(
+    private val repository: ArrangementRepository
+) {
+    suspend operator fun invoke(structure: ArrangementStructure) {
+        repository.saveArrangement(structure)
+    }
+}


### PR DESCRIPTION
## Summary
- create arrangement domain models and use cases
- add fake arrangement repository and entity in data module
- wire arrangement repository via `AppModule`
- implement `ArrangementViewModel` and canvas UI
- add export screen and navigation routes
- provide unit tests for `ArrangementViewModel`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853edbf415c8331a998a5a8b44a2afe