### PR TITLE
Implement new project creation flow

### DIFF
--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/AppModule.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/AppModule.kt
@@ -1,8 +1,10 @@
 package com.clockworkred.app
 
 import com.clockworkred.data.repository.FakeArrangementRepository
+import com.clockworkred.data.repository.FakeProjectRepository
 import com.clockworkred.data.repository.SettingsRepositoryImpl
 import com.clockworkred.domain.ArrangementRepository
+import com.clockworkred.domain.ProjectRepository
 import com.clockworkred.domain.repository.SettingsRepository
 import dagger.Binds
 import dagger.Module
@@ -17,6 +19,10 @@ abstract class AppModule {
     @Binds
     @Singleton
     abstract fun bindArrangementRepository(impl: FakeArrangementRepository): ArrangementRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindProjectRepository(impl: FakeProjectRepository): ProjectRepository
 
     @Binds
     @Singleton

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 @Composable
 fun HomeNavGraph(navController: NavHostController) {
     NavHost(navController = navController, startDestination = "projects") {
-        composable("projects") { ProjectsScreen() }
+        composable("projects") { ProjectsScreen(navController) }
         composable("editor/{instrument}") { backStackEntry ->
             val instrumentName = backStackEntry.arguments?.getString("instrument") ?: "guitar"
             val instrument = runCatching { Instrument.valueOf(instrumentName.uppercase()) }.getOrDefault(Instrument.GUITAR)

--- a/ClockworkRed/app/src/test/java/com/clockworkred/app/projects/ProjectsViewModelTest.kt
+++ b/ClockworkRed/app/src/test/java/com/clockworkred/app/projects/ProjectsViewModelTest.kt
@@ -1,10 +1,16 @@
 package com.clockworkred.app.projects
 
-import com.clockworkred.data.repository.FakeProjectRepository
+import com.clockworkred.domain.ProjectRepository
+import com.clockworkred.domain.model.ProjectModel
+import com.clockworkred.domain.usecase.CreateProjectUseCase
 import com.clockworkred.domain.usecase.GetAllProjectsUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.delay
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -14,12 +20,32 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProjectsViewModelTest {
     private lateinit var viewModel: ProjectsViewModel
+    private lateinit var repo: TestProjectRepository
 
     @Before
     fun setup() {
-        val repo = FakeProjectRepository()
-        val useCase = GetAllProjectsUseCase(repo)
-        viewModel = ProjectsViewModel(useCase)
+        repo = TestProjectRepository()
+        val getUseCase = GetAllProjectsUseCase(repo)
+        val createUseCase = CreateProjectUseCase(repo)
+        viewModel = ProjectsViewModel(getUseCase, createUseCase)
+    }
+
+    private class TestProjectRepository(var shouldFail: Boolean = false) : ProjectRepository {
+        override fun getAllProjects(): Flow<List<ProjectModel>> = flow {
+            delay(500)
+            emit(
+                listOf(
+                    ProjectModel("1", "Alpha", 0L),
+                    ProjectModel("2", "Beta", 0L),
+                    ProjectModel("3", "Gamma", 0L)
+                )
+            )
+        }
+
+        override suspend fun createProject(name: String): ProjectModel {
+            if (shouldFail) throw RuntimeException("fail")
+            return ProjectModel("id", name, 0L)
+        }
     }
 
     @Test
@@ -28,5 +54,24 @@ class ProjectsViewModelTest {
         advanceTimeBy(600)
         assertFalse(viewModel.uiState.value.isLoading)
         assertEquals(3, viewModel.uiState.value.projects.size)
+    }
+
+    @Test
+    fun createProject_successUpdatesState() = runTest {
+        advanceUntilIdle()
+        viewModel.createProject("New")
+        assertTrue(viewModel.uiState.value.isCreating)
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isCreating)
+        assertEquals(1, viewModel.uiState.value.projects.size)
+    }
+
+    @Test
+    fun createProject_failureSetsError() = runTest {
+        repo.shouldFail = true
+        advanceUntilIdle()
+        viewModel.createProject("Bad")
+        advanceUntilIdle()
+        assertEquals("fail", viewModel.uiState.value.creationError)
     }
 }

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/DataModule.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/DataModule.kt
@@ -1,12 +1,10 @@
 package com.clockworkred.data
 
-import com.clockworkred.domain.ProjectRepository
 import com.clockworkred.domain.repository.SettingsRepository
 import com.clockworkred.domain.AiRepository
 import com.clockworkred.data.remote.AiService
 import com.clockworkred.data.remote.ApiKeyInterceptor
 import com.clockworkred.data.repository.AiRepositoryImpl
-import com.clockworkred.data.repository.FakeProjectRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -20,10 +18,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class DataModule {
-
-    @Binds
-    @Singleton
-    abstract fun bindProjectRepository(impl: FakeProjectRepository): ProjectRepository
 
     @Binds
     @Singleton

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/FakeProjectRepository.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/FakeProjectRepository.kt
@@ -2,6 +2,7 @@ package com.clockworkred.data.repository
 
 import com.clockworkred.domain.ProjectRepository
 import com.clockworkred.domain.model.ProjectModel
+import java.util.UUID
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -19,5 +20,11 @@ class FakeProjectRepository @Inject constructor() : ProjectRepository {
             ProjectEntity("3", "Gamma", System.currentTimeMillis())
         ).map { ProjectModel(it.id, it.name, it.createdAt) }
         emit(projects)
+    }
+
+    override suspend fun createProject(name: String): ProjectModel {
+        // TODO persist the project when real data layer is implemented
+        val entity = ProjectEntity(UUID.randomUUID().toString(), name, System.currentTimeMillis())
+        return ProjectModel(entity.id, entity.name, entity.createdAt)
     }
 }

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/ProjectRepository.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/ProjectRepository.kt
@@ -6,4 +6,6 @@ import kotlinx.coroutines.flow.Flow
 /** Repository for accessing projects. */
 interface ProjectRepository {
     fun getAllProjects(): Flow<List<ProjectModel>>
+    /** Creates a new project with the given [name]. */
+    suspend fun createProject(name: String): ProjectModel
 }

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/CreateProjectUseCase.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/CreateProjectUseCase.kt
@@ -1,0 +1,14 @@
+package com.clockworkred.domain.usecase
+
+import com.clockworkred.domain.ProjectRepository
+import com.clockworkred.domain.model.ProjectModel
+import javax.inject.Inject
+
+/** Use case for creating a new project. */
+class CreateProjectUseCase @Inject constructor(
+    private val repository: ProjectRepository
+) {
+    suspend operator fun invoke(name: String): Result<ProjectModel> = runCatching {
+        repository.createProject(name)
+    }
+}


### PR DESCRIPTION
## Summary
- add `CreateProjectUseCase`
- extend `ProjectRepository` with `createProject`
- implement creation in `FakeProjectRepository`
- bind repository in `AppModule`
- update `ProjectsViewModel` with creation logic
- add dialog and navigation logic in `ProjectsScreen`
- wire navigation graph to new screen API
- add tests for project creation
- cleanup DataModule

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853f6a923c0833197f2d9aa163e245c