### PR TITLE
Implement Theory Helper

### DIFF
--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/AppModule.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/AppModule.kt
@@ -3,9 +3,11 @@ package com.clockworkred.app
 import com.clockworkred.data.repository.FakeArrangementRepository
 import com.clockworkred.data.repository.FakeProjectRepository
 import com.clockworkred.data.repository.SettingsRepositoryImpl
+import com.clockworkred.data.repository.TheoryRepositoryImpl
 import com.clockworkred.domain.ArrangementRepository
 import com.clockworkred.domain.ProjectRepository
 import com.clockworkred.domain.repository.SettingsRepository
+import com.clockworkred.domain.repository.TheoryRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -27,4 +29,8 @@ abstract class AppModule {
     @Binds
     @Singleton
     abstract fun bindSettingsRepository(impl: SettingsRepositoryImpl): SettingsRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindTheoryRepository(impl: TheoryRepositoryImpl): TheoryRepository
 }

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/HomeNavGraph.kt
@@ -9,10 +9,12 @@ import com.clockworkred.app.ui.editor.TabEditorScreen
 import com.clockworkred.app.ui.arrangement.ArrangementCanvasScreen
 import com.clockworkred.app.ui.export.ExportScreen
 import com.clockworkred.app.ui.settings.SettingsScreen
+import com.clockworkred.app.ui.theory.TheoryHelperScreen
 import com.clockworkred.app.editor.TabEditorViewModel
 import com.clockworkred.domain.model.Instrument
 import com.clockworkred.domain.model.PartRequest
 import com.clockworkred.domain.model.SongSection
+import com.clockworkred.domain.model.TheoryTopic
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.runtime.LaunchedEffect
 
@@ -27,10 +29,15 @@ fun HomeNavGraph(navController: NavHostController) {
             LaunchedEffect(instrument) {
                 viewModel.requestTab(PartRequest(instrument, "", emptyList(), SongSection.CHORUS))
             }
-            TabEditorScreen(viewModel)
+            TabEditorScreen(navController, viewModel)
         }
         composable("settings") { SettingsScreen() }
         composable("arrangement") { ArrangementCanvasScreen(navController) }
         composable("export") { ExportScreen() }
+        composable("theory/{topic}") { backStackEntry ->
+            val topicName = backStackEntry.arguments?.getString("topic") ?: TheoryTopic.SCALE.name
+            val topic = runCatching { TheoryTopic.valueOf(topicName.uppercase()) }.getOrDefault(TheoryTopic.SCALE)
+            TheoryHelperScreen(topic = topic)
+        }
     }
 }

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/theory/TheoryViewModel.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/theory/TheoryViewModel.kt
@@ -1,0 +1,41 @@
+package com.clockworkred.app.theory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clockworkred.domain.model.TheoryNote
+import com.clockworkred.domain.model.TheoryTopic
+import com.clockworkred.domain.usecase.GetTheoryNoteUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** ViewModel for fetching theory notes. */
+@HiltViewModel
+class TheoryViewModel @Inject constructor(
+    private val getTheoryNote: GetTheoryNoteUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TheoryUiState(isLoading = false, note = null, error = null))
+    val uiState: StateFlow<TheoryUiState> = _uiState
+
+    /** Load the note for the provided [topic]. */
+    fun loadTopic(topic: TheoryTopic) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            val result = getTheoryNote(topic)
+            result.fold(
+                onSuccess = { note -> _uiState.value = TheoryUiState(false, note, null) },
+                onFailure = { err -> _uiState.value = TheoryUiState(false, null, err.message) }
+            )
+        }
+    }
+}
+
+/** UI state for [TheoryHelperScreen]. */
+data class TheoryUiState(
+    val isLoading: Boolean,
+    val note: TheoryNote?,
+    val error: String?
+)

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/editor/TabEditorScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/editor/TabEditorScreen.kt
@@ -19,9 +19,14 @@ import com.clockworkred.app.editor.TabEditorViewModel
 import com.clockworkred.domain.model.Instrument
 import com.clockworkred.domain.model.PartRequest
 import com.clockworkred.domain.model.SongSection
+import androidx.navigation.NavHostController
+import com.clockworkred.domain.model.TheoryTopic
 
 @Composable
-fun TabEditorScreen(viewModel: TabEditorViewModel = hiltViewModel()) {
+fun TabEditorScreen(
+    navController: NavHostController,
+    viewModel: TabEditorViewModel = hiltViewModel()
+) {
     val uiState by viewModel.uiState.collectAsState()
 
     val instrument = remember { mutableStateOf(Instrument.GUITAR) }
@@ -115,6 +120,9 @@ fun TabEditorScreen(viewModel: TabEditorViewModel = hiltViewModel()) {
                 uiState.theoryNotes?.let {
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(it)
+                    TextButton(onClick = { navController.navigate("theory/${TheoryTopic.MODE.name.lowercase()}") }) {
+                        Text("Theory Help")
+                    }
                 }
             }
         }

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/theory/TheoryHelperScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/theory/TheoryHelperScreen.kt
@@ -1,0 +1,50 @@
+package com.clockworkred.app.ui.theory
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.clockworkred.app.theory.TheoryViewModel
+import com.clockworkred.app.theory.TheoryUiState
+import com.clockworkred.domain.model.TheoryTopic
+
+@Composable
+fun TheoryHelperScreen(
+    viewModel: TheoryViewModel = hiltViewModel(),
+    topic: TheoryTopic
+) {
+    LaunchedEffect(topic) { viewModel.loadTopic(topic) }
+    val uiState by viewModel.uiState.collectAsState()
+
+    when {
+        uiState.isLoading -> {
+            CircularProgressIndicator()
+        }
+        uiState.error != null -> {
+            Snackbar { Text(uiState.error!!) }
+        }
+        uiState.note != null -> {
+            val note = uiState.note
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(note.title, style = MaterialTheme.typography.headlineSmall)
+                Text(note.description, style = MaterialTheme.typography.bodyMedium)
+                LazyColumn(modifier = Modifier.padding(top = 8.dp)) {
+                    items(note.examples) { example ->
+                        Text("- $example", style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ClockworkRed/app/src/test/java/com/clockworkred/app/theory/TheoryViewModelTest.kt
+++ b/ClockworkRed/app/src/test/java/com/clockworkred/app/theory/TheoryViewModelTest.kt
@@ -1,0 +1,52 @@
+package com.clockworkred.app.theory
+
+import com.clockworkred.domain.model.TheoryNote
+import com.clockworkred.domain.model.TheoryTopic
+import com.clockworkred.domain.usecase.GetTheoryNoteUseCase
+import com.clockworkred.domain.repository.TheoryRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+private class FakeTheoryRepository(
+    private val result: Result<TheoryNote>
+) : TheoryRepository {
+    override suspend fun fetchNoteFor(topic: TheoryTopic): TheoryNote {
+        return result.getOrElse { throw it }
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TheoryViewModelTest {
+    private lateinit var successUseCase: GetTheoryNoteUseCase
+    private lateinit var errorUseCase: GetTheoryNoteUseCase
+
+    @Before
+    fun setup() {
+        successUseCase = GetTheoryNoteUseCase(FakeTheoryRepository(Result.success(TheoryNote("title", "desc", emptyList()))))
+        errorUseCase = GetTheoryNoteUseCase(FakeTheoryRepository(Result.failure(RuntimeException("fail"))))
+    }
+
+    @Test
+    fun loadTopic_successUpdatesState() = runTest {
+        val viewModel = TheoryViewModel(successUseCase)
+        viewModel.loadTopic(TheoryTopic.SCALE)
+        assertTrue(viewModel.uiState.value.isLoading)
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertEquals("title", viewModel.uiState.value.note?.title)
+    }
+
+    @Test
+    fun loadTopic_errorSetsMessage() = runTest {
+        val viewModel = TheoryViewModel(errorUseCase)
+        viewModel.loadTopic(TheoryTopic.SCALE)
+        advanceUntilIdle()
+        assertEquals("fail", viewModel.uiState.value.error)
+    }
+}

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/TheoryRepositoryImpl.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/TheoryRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.clockworkred.data.repository
+
+import com.clockworkred.domain.model.TheoryNote
+import com.clockworkred.domain.model.TheoryTopic
+import com.clockworkred.domain.repository.TheoryRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Simple in-memory implementation of [TheoryRepository]. */
+@Singleton
+class TheoryRepositoryImpl @Inject constructor() : TheoryRepository {
+    private val notes = mapOf(
+        TheoryTopic.SCALE to TheoryNote(
+            title = "Scales",
+            description = "A scale is a sequence of notes in ascending or descending order.",
+            examples = listOf("C Major: C D E F G A B", "A Minor: A B C D E F G")
+        ),
+        TheoryTopic.MODE to TheoryNote(
+            title = "Modes",
+            description = "Modes are variations of scales with unique tonalities.",
+            examples = listOf("Dorian: starting on the second degree of the major scale")
+        ),
+        TheoryTopic.CHORD_FUNCTION to TheoryNote(
+            title = "Chord Functions",
+            description = "Chord functions describe the role a chord plays in harmony.",
+            examples = listOf("Tonic - the home chord", "Dominant - creates tension")
+        ),
+        TheoryTopic.RHYTHM_PATTERN to TheoryNote(
+            title = "Rhythm Patterns",
+            description = "Rhythm patterns organize beats into repeating units.",
+            examples = listOf("Backbeat on 2 and 4", "Bossa nova clave")
+        )
+    )
+
+    override suspend fun fetchNoteFor(topic: TheoryTopic): TheoryNote {
+        // TODO replace with AI-powered fetch or JSON-backed local data
+        return notes[topic] ?: TheoryNote("Unknown", "No information available", emptyList())
+    }
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/model/TheoryNote.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/model/TheoryNote.kt
@@ -1,0 +1,8 @@
+package com.clockworkred.domain.model
+
+/** Detailed explanation for a theory topic. */
+data class TheoryNote(
+    val title: String,
+    val description: String,
+    val examples: List<String>
+)

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/model/TheoryTopic.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/model/TheoryTopic.kt
@@ -1,0 +1,9 @@
+package com.clockworkred.domain.model
+
+/** Topics supported by the theory helper. */
+enum class TheoryTopic {
+    SCALE,
+    MODE,
+    CHORD_FUNCTION,
+    RHYTHM_PATTERN
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/repository/TheoryRepository.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/repository/TheoryRepository.kt
@@ -1,0 +1,10 @@
+package com.clockworkred.domain.repository
+
+import com.clockworkred.domain.model.TheoryNote
+import com.clockworkred.domain.model.TheoryTopic
+
+/** Repository providing theory notes for the helper feature. */
+interface TheoryRepository {
+    /** Fetch the note for the given topic. */
+    suspend fun fetchNoteFor(topic: TheoryTopic): TheoryNote
+}

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/GetTheoryNoteUseCase.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/usecase/GetTheoryNoteUseCase.kt
@@ -1,0 +1,15 @@
+package com.clockworkred.domain.usecase
+
+import com.clockworkred.domain.model.TheoryNote
+import com.clockworkred.domain.model.TheoryTopic
+import com.clockworkred.domain.repository.TheoryRepository
+import javax.inject.Inject
+
+/** Use case fetching a theory note for a given topic. */
+class GetTheoryNoteUseCase @Inject constructor(
+    private val theoryRepository: TheoryRepository
+) {
+    suspend operator fun invoke(topic: TheoryTopic): Result<TheoryNote> = runCatching {
+        theoryRepository.fetchNoteFor(topic)
+    }
+}


### PR DESCRIPTION
## Summary
- add theory domain models, repository interface and use case
- implement simple TheoryRepositoryImpl with hard-coded data
- expose TheoryViewModel and Compose TheoryHelperScreen
- integrate into TabEditorScreen and navigation
- cover TheoryViewModel with unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853f90d88188331981c82694ff76e76