### PR TITLE
Add Android production readiness configs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,30 @@
+name: Android CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - uses: gradle/gradle-build-action@v2
+      - name: Run Static Analysis
+        run: ./gradlew detekt ktlintCheck lint
+      - name: Run Tests
+        run: ./gradlew testDebugUnitTest connectedDebugAndroidTest
+      - name: Accessibility Scanner
+        run: ./gradlew accessibilityTest
+      - name: Assemble Releases
+        run: ./gradlew assembleRelease
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: '**/build/reports/tests'
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/app-release.apk

--- a/ClockworkRed/app/build.gradle.kts
+++ b/ClockworkRed/app/build.gradle.kts
@@ -2,7 +2,16 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.dagger.hilt.android")
+    id("com.google.firebase.crashlytics")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.jlleitschuh.gradle.ktlint")
+    // TODO integrate APEChecker once available
     kotlin("kapt")
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    baseline = file("detekt-baseline.xml")
 }
 
 android {
@@ -15,6 +24,24 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isDebuggable = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    productFlavors {
+        create("dev") {}
+        create("staging") {}
+        create("prod") {}
     }
 
     buildFeatures {
@@ -32,6 +59,12 @@ android {
 
     kotlinOptions {
         jvmTarget = "17"
+    }
+
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
     }
 }
 
@@ -55,9 +88,22 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
+    implementation(platform("com.google.firebase:firebase-bom:32.3.1"))
+    implementation("com.google.firebase:firebase-crashlytics")
+    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-perf")
+    implementation("com.google.firebase:firebase-config")
+
+    implementation("org.permissionsdispatcher:permissionsdispatcher-ktx:4.9.2")
+    kapt("org.permissionsdispatcher:permissionsdispatcher-processor:4.9.2")
+
+    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.12")
+
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("org.mockito:mockito-core:5.11.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 }

--- a/ClockworkRed/app/proguard-rules.pro
+++ b/ClockworkRed/app/proguard-rules.pro
@@ -1,0 +1,8 @@
+# Strip all Log calls in release
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+}

--- a/ClockworkRed/app/src/androidTest/java/com/clockworkred/app/ui/projects/ProjectsScreenTest.kt
+++ b/ClockworkRed/app/src/androidTest/java/com/clockworkred/app/ui/projects/ProjectsScreenTest.kt
@@ -1,0 +1,26 @@
+package com.clockworkred.app.ui.projects
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.rememberNavController
+import androidx.test.platform.app.InstrumentationRegistry
+import com.clockworkred.app.R
+import org.junit.Rule
+import org.junit.Test
+
+/** Basic UI test verifying project list empty state. */
+class ProjectsScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun showsEmptyState() {
+        composeTestRule.setContent {
+            ProjectsScreen(navController = rememberNavController())
+        }
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        composeTestRule.onNodeWithText(ctx.getString(R.string.no_projects)).assertExists()
+        composeTestRule.onNodeWithText(ctx.getString(R.string.new_project)).performClick()
+    }
+}

--- a/ClockworkRed/app/src/dev/google-services.json
+++ b/ClockworkRed/app/src/dev/google-services.json
@@ -1,0 +1,1 @@
+{"project_info":{}}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ClockworkRedApp.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ClockworkRedApp.kt
@@ -1,7 +1,16 @@
 package com.clockworkred.app
 
 import android.app.Application
+import com.google.firebase.FirebaseApp
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class ClockworkRedApp : Application()
+class ClockworkRedApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        FirebaseApp.initializeApp(this)
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true)
+        // TODO initialize Firebase Performance and Analytics if needed
+    }
+}

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/MainActivity.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/MainActivity.kt
@@ -7,8 +7,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import permissions.dispatcher.NeedsPermission
+import permissions.dispatcher.RuntimePermissions
 
 @AndroidEntryPoint
+@RuntimePermissions
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,5 +23,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    /** Example permission gated call. */
+    @NeedsPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE)
+    fun exportFiles() {
+        // TODO implement export logic
     }
 }

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/export/ExportScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/export/ExportScreen.kt
@@ -5,22 +5,24 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.clockworkred.app.R
 
 /** Screen offering export options for an arrangement. */
 @Composable
 fun ExportScreen() {
     Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
         Button(onClick = { /* TODO generate and save PDF to storage */ }, modifier = Modifier.fillMaxWidth()) {
-            Text("Download PDF")
+            Text(stringResource(id = R.string.download_pdf))
         }
         Button(onClick = { /* TODO share generated PDF */ }, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-            Text("Share PDF")
+            Text(stringResource(id = R.string.share_pdf))
         }
         Button(onClick = { /* TODO export MIDI file */ }, modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-            Text("Export MIDI")
+            Text(stringResource(id = R.string.export_midi))
         }
         // TODO request WRITE_EXTERNAL_STORAGE permission when implementing file operations
     }

--- a/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/projects/ProjectsScreen.kt
+++ b/ClockworkRed/app/src/main/java/com/clockworkred/app/ui/projects/ProjectsScreen.kt
@@ -14,10 +14,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
+import androidx.compose.ui.res.stringResource
 import com.clockworkred.app.projects.ProjectsUiState
 import com.clockworkred.app.projects.ProjectsViewModel
 import androidx.navigation.NavHostController
 import androidx.compose.material3.MaterialTheme
+import com.clockworkred.app.R
 
 /** Displays list of projects. */
 @Composable
@@ -32,13 +34,13 @@ fun ProjectsScreen(
     if (showDialog) {
         AlertDialog(
             onDismissRequest = { if (!uiState.isCreating) showDialog = false },
-            title = { Text("New Project") },
+            title = { Text(stringResource(id = R.string.new_project)) },
             text = {
                 Column {
                     TextField(
                         value = name,
                         onValueChange = { name = it },
-                        label = { Text("Project Name") },
+                        label = { Text(stringResource(id = R.string.project_name)) },
                         modifier = Modifier.fillMaxWidth()
                     )
                     uiState.creationError?.let {
@@ -53,12 +55,12 @@ fun ProjectsScreen(
             },
             confirmButton = {
                 TextButton(onClick = { viewModel.createProject(name) }, enabled = !uiState.isCreating) {
-                    Text("Create")
+                    Text(stringResource(id = R.string.create))
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showDialog = false }, enabled = !uiState.isCreating) {
-                    Text("Cancel")
+                    Text(stringResource(id = R.string.cancel))
                 }
             }
         )
@@ -78,10 +80,10 @@ fun ProjectsScreen(
             }
             uiState.projects.isEmpty() -> {
                 Column(modifier = Modifier.align(Alignment.Center)) {
-                    Text("No projects yet")
+                    Text(stringResource(id = R.string.no_projects))
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(onClick = { showDialog = true }) {
-                        Text("New Project")
+                        Text(stringResource(id = R.string.new_project))
                     }
                 }
             }

--- a/ClockworkRed/app/src/main/res/values-es/strings.xml
+++ b/ClockworkRed/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">ClockworkRojo</string>
+    <string name="new_project">Nuevo Proyecto</string>
+    <string name="project_name">Nombre del Proyecto</string>
+    <string name="create">Crear</string>
+    <string name="cancel">Cancelar</string>
+    <string name="no_projects">Aún no hay proyectos</string>
+    <string name="download_pdf">Descargar PDF</string>
+    <string name="share_pdf">Compartir PDF</string>
+    <string name="export_midi">Exportar MIDI</string>
+</resources>

--- a/ClockworkRed/app/src/main/res/values/strings.xml
+++ b/ClockworkRed/app/src/main/res/values/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">ClockworkRed</string>
+    <string name="new_project">New Project</string>
+    <string name="project_name">Project Name</string>
+    <string name="create">Create</string>
+    <string name="cancel">Cancel</string>
+    <string name="no_projects">No projects yet</string>
+    <string name="download_pdf">Download PDF</string>
+    <string name="share_pdf">Share PDF</string>
+    <string name="export_midi">Export MIDI</string>
+</resources>

--- a/ClockworkRed/app/src/prod/google-services.json
+++ b/ClockworkRed/app/src/prod/google-services.json
@@ -1,0 +1,1 @@
+{"project_info":{}}

--- a/ClockworkRed/app/src/staging/google-services.json
+++ b/ClockworkRed/app/src/staging/google-services.json
@@ -1,0 +1,1 @@
+{"project_info":{}}

--- a/ClockworkRed/app/src/test/java/com/clockworkred/app/projects/ProjectsViewModelJUnit5Test.kt
+++ b/ClockworkRed/app/src/test/java/com/clockworkred/app/projects/ProjectsViewModelJUnit5Test.kt
@@ -1,0 +1,21 @@
+package com.clockworkred.app.projects
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/** Simple JUnit5 test ensuring initial loading state. */
+class ProjectsViewModelJUnit5Test {
+    @Test
+    fun startsLoading() = runTest {
+        val repo = object : com.clockworkred.domain.ProjectRepository {
+            override fun getAllProjects() = kotlinx.coroutines.flow.flow<List<com.clockworkred.domain.model.ProjectModel>> { emit(emptyList()) }
+            override suspend fun createProject(name: String) = com.clockworkred.domain.model.ProjectModel("id", name, 0L)
+        }
+        val viewModel = ProjectsViewModel(
+            com.clockworkred.domain.usecase.GetAllProjectsUseCase(repo),
+            com.clockworkred.domain.usecase.CreateProjectUseCase(repo)
+        )
+        assertTrue(viewModel.uiState.value.isLoading)
+    }
+}

--- a/ClockworkRed/build.gradle.kts
+++ b/ClockworkRed/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
     id("com.android.library") version "8.1.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false
+    id("com.google.firebase.crashlytics") version "2.9.9" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.23.1" apply false
+    id("org.jlleitschuh.gradle.ktlint") version "11.5.1" apply false
 }
 
 allprojects {

--- a/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/SettingsRepositoryImpl.kt
+++ b/ClockworkRed/data/src/main/java/com/clockworkred/data/repository/SettingsRepositoryImpl.kt
@@ -26,4 +26,9 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun saveApiKey(key: String) {
         context.dataStore.edit { it[API_KEY] = key }
     }
+
+    override suspend fun fetchRemoteFlags(): Map<String, String> {
+        // TODO integrate Firebase Remote Config
+        return emptyMap()
+    }
 }

--- a/ClockworkRed/detekt-baseline.xml
+++ b/ClockworkRed/detekt-baseline.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<smell-baseline version="2.0"></smell-baseline>

--- a/ClockworkRed/domain/src/main/java/com/clockworkred/domain/repository/SettingsRepository.kt
+++ b/ClockworkRed/domain/src/main/java/com/clockworkred/domain/repository/SettingsRepository.kt
@@ -9,4 +9,7 @@ interface SettingsRepository {
 
     /** Saves the provided API key. */
     suspend fun saveApiKey(key: String)
+
+    /** Fetches feature flags from remote config service. */
+    suspend fun fetchRemoteFlags(): Map<String, String>
 }


### PR DESCRIPTION
## Summary
- enable release build optimizations and product flavors
- integrate Firebase Crashlytics and Remote Config stubs
- set up detekt, ktlint and LeakCanary
- add runtime permission handling
- extract a few strings and add Spanish translations
- add tests and GitHub Actions workflow

## Testing
- `./gradlew tasks --all` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6853fe696e808331897ce4d9774cde6f